### PR TITLE
Build 64 bit and 32 bit builds using GitHub Actions

### DIFF
--- a/.github/workflows/Linux-release.yml
+++ b/.github/workflows/Linux-release.yml
@@ -21,5 +21,5 @@ jobs:
     - name: Upload Ubuntu Application
       uses: actions/upload-artifact@v2
       with:
-        name: Ubuntu Application
+        name: Linux-Application
         path: /home/runner/work/Redux/Redux/build/src/app

--- a/.github/workflows/win-release32.yml
+++ b/.github/workflows/win-release32.yml
@@ -1,0 +1,20 @@
+name: Windows
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: |
+        vcpkg install cryptopp:x86-windows
+        cmake -G "Visual Studio 16 2019" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake --build build32 --config Release
+    - name: Upload Windows Application
+      uses: actions/upload-artifact@v2
+      with:
+        name: Windows-Applicationx86
+        path: D:\a\Redux\Redux\build32\src\Release\app.exe

--- a/.github/workflows/win-release32.yml
+++ b/.github/workflows/win-release32.yml
@@ -1,4 +1,4 @@
-name: Windows
+name: Windows-32
 
 on: [push]
 

--- a/.github/workflows/win-release64.yml
+++ b/.github/workflows/win-release64.yml
@@ -1,4 +1,4 @@
-name: Windows
+name: Windows-64
 
 on: [push]
 

--- a/.github/workflows/win-release64.yml
+++ b/.github/workflows/win-release64.yml
@@ -11,12 +11,10 @@ jobs:
     - name: build
       run: |
         vcpkg install cryptopp:x64-windows
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
-        cmake --build . --config Release
+        cmake -G "Visual Studio 16 2019" -A x64 -S . -B "build64" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake --build build64 --config Release
     - name: Upload Windows Application
       uses: actions/upload-artifact@v2
       with:
-        name: Windows Application
-        path: D:\a\Redux\Redux\build\src\Release\app.exe
+        name: Windows-Applicationx64
+        path: D:\a\Redux\Redux\build64\src\Release\app.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.vscode
 /.clangd
 /build
+/build64
+/build32
 /compile_commands.json
 /CMakeFiles
 build_Redux.bat


### PR DESCRIPTION
These Series of Commits will let GitHub actions Upload 64 bit and 32 bit of Redux Build Variant.