### PR TITLE
Turn off echo of password in linux, prompt change password two times

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cmake --build /home/username/Repos/Redux/build
 ```
 5. Run The Executable:
 ``` 
-./build/src/app 
+./build/src/Redux
 ```
 
 
@@ -59,7 +59,7 @@ cmake --build /home/username/Repos/Redux/build
 4. Open **Redux.sln**[```Redux\build```] in Visual Studio 2019.
 5. In Solution Explorer, right click on ```app``` and click on **Set as Startup Project**.
 6. Set Solution Configuartions as **Release**, and Build App ```[Ctrl+B]```.
-7. Binaries will be provided in ```\Redux\build\src\Release\app.exe```.
+7. Binaries will be provided in ```\Redux\build\src\Release\Redux.exe```.
 
 ## Notes (if using Pre-Build Binaries for Windows):
 

--- a/include/str.h
+++ b/include/str.h
@@ -90,6 +90,7 @@ namespace str {
 
     str_type password = "Enter your Password: ";
     str_type username = "Enter your Username: ";
+    str_type password_again = "For Security Reasons please enter your password again";
 
     str_type choice = "Enter your choice: ";
     str_type empty = "Empty.\n";

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -9,6 +9,9 @@
 #include <iostream>
 #include <string>
 #include <utility>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 namespace login {
     static void exceeds_attempt() {
@@ -35,8 +38,11 @@ namespace login {
 
     static auto valid_password(user const& other) {
         user user{other.name};
+#ifdef _WIN32
         user.password = input::line(str::password);
-
+#else
+        user.password = getpass(str::password);
+#endif
         int input_attempt = 0;
         while (!account::valid_password(user)) {
             if (++input_attempt == 3) {
@@ -45,7 +51,11 @@ namespace login {
             }
 
             std::cout << user.name << str::ac_pass_incorrect;
+#ifdef _WIN32
             user.password = input::line(str::password);
+#else
+            user.password = getpass(str::password);
+#endif
         }
 
         return std::make_pair(true, user.password);

--- a/src/logout.cpp
+++ b/src/logout.cpp
@@ -17,11 +17,23 @@ void user_logout(user const& user) {
 }
 
 bool change_password(user const& user_) {
+    std::cout << "\n";
     auto [valid, new_password] = signup::valid_password();
     if (!valid) {
         return false;
     }
+    std::cout << str::password_again << "\n";
+    auto [valid_again, new_password_again] = signup::valid_password();
+    if (!valid_again) {
+        return false;
+    }
 
+    if (new_password != new_password_again) {
+        std::cout << str::clear_screen;
+        std::cout << "Password do not match\n";
+        input::enter();
+        return false;
+    }
     account::change_password(user_, new_password);
 
     std::cout << str::clear_screen << "Password Changed\n\n";

--- a/src/signup.cpp
+++ b/src/signup.cpp
@@ -9,6 +9,9 @@
 #include <iostream>
 #include <string>
 #include <utility>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 namespace signup {
     static void exceeds_attempt() {
@@ -34,7 +37,11 @@ namespace signup {
     }
 
     std::pair<bool, std::string> valid_password() {
+#ifdef _WIN32
         std::string password = input::line(str::password);
+#else
+        std::string password = getpass(str::password);
+#endif
 
         int input_attempt = 0;
         constexpr auto min_pass_len = 8;
@@ -45,7 +52,11 @@ namespace signup {
             }
 
             std::cout << str::min_pass_len << min_pass_len << "\n\n";
+#ifdef _WIN32
             password = input::line(str::password);
+#else
+            password = getpass(str::password);
+#endif
         }
 
         return {true, password};


### PR DESCRIPTION
This PR adds two new features:
1. Password will not be shown in the Linux terminal
2. While changing the password, the user will have to enter the password two times before the password changes.