### PR TITLE
Make storage failures loud, validate usernames, and add regression tests

### DIFF
--- a/.github/workflows/Linux-release.yml
+++ b/.github/workflows/Linux-release.yml
@@ -17,7 +17,10 @@ jobs:
         cd build
         cmake .. -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_CXX_COMPILER=g++-11
         cmake --build .
-        strip src/Redux
+    - name: test
+      run: ctest --test-dir build --output-on-failure
+    - name: strip
+      run: strip build/src/Redux
     - name: Upload Ubuntu Application
       uses: actions/upload-artifact@v4
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,11 @@ project(
 )
 
 add_subdirectory(src)
+
+# The regression tests relocate the config directory by overriding HOME, which is how the POSIX
+# build resolves it. The Windows build uses GetUserProfileDirectory instead, so they are not
+# portable as written.
+if(NOT WIN32)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/include/account.h
+++ b/include/account.h
@@ -6,6 +6,11 @@
 struct user;
 
 namespace account {
+    // A username becomes a filename, so it must not be able to alter the path it builds. Rejects
+    // separators, traversal, absolute paths, and names that could collide with Redux's own state
+    // files. Check this before any path is derived from a username.
+    bool valid_username(std::string const& username);
+
     bool exists(std::string const& username);
     bool valid_password(user const&);
     void create(user const&);

--- a/include/input.h
+++ b/include/input.h
@@ -3,11 +3,18 @@
 
 #include "str.h"
 
+#include <stdexcept>
 #include <string>
 
 namespace input {
+    // Thrown when stdin is exhausted: Ctrl-D, or a redirected stdin that ran out. Quitting that
+    // way is a normal user action, so main treats it as a clean exit rather than an error.
+    struct end_of_input : std::runtime_error {
+        end_of_input() : std::runtime_error{"end of input"} {}
+    };
+
     auto line(char const* msg) -> std::string;
-    // As `line`, but empty input (or end of stream) yields `fallback` instead of re-prompting.
+    // As `line`, but empty input yields `fallback` instead of re-prompting.
     auto line_or(char const* msg, std::string const& fallback) -> std::string;
     auto choice(char const* msg = str::choice) -> int;
     auto enter(char const* msg = nullptr) -> void;

--- a/include/str.h
+++ b/include/str.h
@@ -108,6 +108,9 @@ namespace str {
     str_type ac_not_exists = "'s account doesn't exists.\n\n";
     str_type ac_pass_incorrect = "'s password is not correct.\n\n";
     str_type ac_already_exists = "'s account is already exists.\n\n";
+    str_type invalid_username =
+        "A username must start with a letter or digit and may contain only letters, digits, "
+        "'.', '-' and '_', up to 64 characters.\n\n";
     str_type min_pass_len = "Minimum password length is ";
 
     str_type credential_to_remove = "Enter the credential id to remove: ";

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,14 +2,12 @@
 #define UTILS_H
 
 #include <string>
-#ifndef _WIN32
-#include <unistd.h>
-#else
-#include <Windows.h>
-#endif
 
 namespace utils {
-    void switchStdinEcho(std::string const& console_mode);
-}
+    // Reads a line of input without echoing it, restoring the terminal on every exit path --
+    // exceptions included. Throwing out of a password prompt used to skip the re-enabling call
+    // and leave the invoking Windows shell with echo switched off.
+    std::string read_password(char const* prompt);
+} // namespace utils
 
-#endif // UTILITY FUNCTIONS
+#endif // UTILS_H

--- a/src/account.cpp
+++ b/src/account.cpp
@@ -1,11 +1,37 @@
 #include "account.h"
+#include "credential.h"
 #include "file.h"
 #include "user.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 namespace account {
+    bool valid_username(std::string const& username) {
+        constexpr std::string::size_type max_len = 64;
+
+        if (username.empty() || username.size() > max_len) {
+            return false;
+        }
+
+        auto is_alnum = [](char c) {
+            return std::isalnum(static_cast<unsigned char>(c)) != 0;
+        };
+
+        // Requiring an alphanumeric first character rules out ".", "..", and Redux's own
+        // dot-prefixed state files in one go.
+        if (!is_alnum(username.front())) {
+            return false;
+        }
+
+        return std::all_of(username.begin(), username.end(), [&](char c) {
+            return is_alnum(c) || c == '_' || c == '-' || c == '.';
+        });
+    }
+
     bool exists(std::string const& username) {
         return std::filesystem::exists(file::user_files::filePath(username));
     }
@@ -34,10 +60,15 @@ namespace account {
 
         // Re-encrypt the vault itself under the new password. Nothing else does this: the files
         // are always encrypted at rest, so there is no logout step left to pick it up.
-        // The two writes are not atomic with respect to each other; see the audit's C3.
-        auto const data = file::crypt::read_decrypted(uf::data(user.name), user.password);
-        file::crypt::write_encrypted(uf::data(user.name), data, password);
+        //
+        // Going through file::credentials rather than crypt directly means an absent vault is
+        // handled here exactly as it is everywhere else, instead of throwing from a code path
+        // that menu item 7 reaches directly.
+        auto const credentials = file::credentials::read(uf::data(user.name), user.password);
+        file::credentials::write(uf::data(user.name), credentials, password);
 
+        // Each write is individually atomic, but the pair is not: an interruption between them
+        // leaves the vault on the new password and the account file on the old one.
         file::crypt::write_encrypted(uf::account(user.name), user.name, password);
     }
 } // namespace account

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,3 +1,23 @@
+#include "input.h"
 #include "startup_services.h"
 
-int main() { startup_services::run(); }
+#include <exception>
+#include <iostream>
+
+int main() {
+    try {
+        startup_services::run();
+    } catch (input::end_of_input const&) {
+        // Ctrl-D or an exhausted redirected stdin. A normal way to quit, not a failure.
+        std::cout << '\n';
+        return 0;
+    } catch (std::exception const& e) {
+        // Anything else -- an unreadable or corrupt vault, a failed write, a filesystem error.
+        // Report it instead of letting it abort the process.
+        std::cerr << "\nRedux stopped: " << e.what() << '\n';
+        return 1;
+    } catch (...) {
+        std::cerr << "\nRedux stopped: unknown error\n";
+        return 1;
+    }
+}

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -162,7 +162,12 @@ namespace file::crypt {
             // CRLF inside it on Windows and corrupt it.
             std::ofstream out{staging, std::ios::binary | std::ios::trunc};
             out.write(ciphertext.data(), static_cast<std::streamsize>(ciphertext.size()));
-            out.flush();
+
+            // Close here rather than letting the destructor do it. Some filesystems only report a
+            // deferred write error when the file is closed, and a destructor has no way to report
+            // it -- the staging file would then be renamed over a good vault while holding
+            // incomplete ciphertext. Checking after the close is what makes the rename safe.
+            out.close();
 
             if (!out) {
                 std::error_code ec;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <iterator>
 #include <sstream>
+#include <stdexcept>
+#include <system_error>
 #ifdef _WIN32
 #include <userenv.h>
 #pragma comment(lib, "Userenv.lib")
@@ -48,7 +50,10 @@ namespace file::user_files {
     std::string filePath(std::string const& username) {
         return (config_dir() / username).string();
     }
-    std::string data(std::string const& username) { return filePath(username) + "_data"; }
+    // '@' cannot appear in a valid username, which is what keeps this suffix from colliding with
+    // another account: with the old "_data" suffix, registering "alice_data" silently took over
+    // the vault belonging to "alice".
+    std::string data(std::string const& username) { return filePath(username) + "@vault"; }
     std::string account(std::string const& username) { return filePath(username); }
 } // namespace file::user_files
 
@@ -142,10 +147,35 @@ namespace file::crypt {
                      new DefaultEncryptorWithMAC{reinterpret_cast<byte const*>(password.data()),
                                                  password.size(), new StringSink{ciphertext}}};
 
-        // Binary: the payload is ciphertext, and a text-mode stream would translate LF to CRLF
-        // inside it on Windows and corrupt it.
-        std::ofstream out{filename, std::ios::binary | std::ios::trunc};
-        out.write(ciphertext.data(), static_cast<std::streamsize>(ciphertext.size()));
+        // Write to a sibling temp file and rename it over the target. Opening the target with
+        // trunc would destroy the old contents before the new bytes were known to be on disk, so
+        // a failing write would leave a 0-byte vault -- unreadable, and unrecoverable.
+        // The staging name is dot-prefixed so it cannot collide with a real user's file: a valid
+        // username must begin with an alphanumeric, so no account file is ever named ".<x>.new".
+        // Naming it "<filename>.new" would mean saving user "alice" clobbers user "alice.new".
+        std::filesystem::path const target{filename};
+        std::filesystem::path const staging =
+            target.parent_path() / ('.' + target.filename().string() + ".new");
+
+        {
+            // Binary: the payload is ciphertext, and a text-mode stream would translate LF to
+            // CRLF inside it on Windows and corrupt it.
+            std::ofstream out{staging, std::ios::binary | std::ios::trunc};
+            out.write(ciphertext.data(), static_cast<std::streamsize>(ciphertext.size()));
+            out.flush();
+
+            if (!out) {
+                std::error_code ec;
+                std::filesystem::remove(staging, ec);
+                throw std::runtime_error{"could not write " + target.string()};
+            }
+        }
+
+        // Owner-only before it is published, so the file is never briefly world-readable.
+        std::filesystem::permissions(staging, std::filesystem::perms::owner_read |
+                                                  std::filesystem::perms::owner_write);
+
+        std::filesystem::rename(staging, target);
     }
 
     std::string read_decrypted(std::string const& filename, std::string const& password) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -23,11 +23,15 @@ namespace input {
         std::cout << msg;
 
         std::string str;
-        while (getline(std::cin, str) && !valid(str)) {
+        while (getline(std::cin, str)) {
+            if (valid(str)) {
+                return trim(str);
+            }
+
             std::cout << str::try_again << msg;
         }
 
-        return trim(str);
+        throw end_of_input{};
     }
 
     std::string line_or(char const* const msg, std::string const& fallback) {
@@ -35,7 +39,7 @@ namespace input {
 
         std::string str;
         if (!getline(std::cin, str)) {
-            return fallback;
+            throw end_of_input{};
         }
 
         auto trimmed = trim(str);
@@ -49,6 +53,12 @@ namespace input {
         int result = 0;
 
         while (!(std::cin >> result)) {
+            // Without this, clear() followed by ignore() re-sets eofbit immediately and the loop
+            // spins forever printing the retry message.
+            if (std::cin.eof()) {
+                throw end_of_input{};
+            }
+
             std::cout << str::try_again << msg;
             std::cin.clear();
             std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -36,8 +36,10 @@ namespace login {
             username = input::line_or(msg.c_str(), remembered);
         }
 
+        // Checking validity first means a rejected name never reaches the filesystem, so a
+        // crafted username cannot be used to probe for files outside the config directory.
         int input_attempt = 0;
-        while (!account::exists(username)) {
+        while (!account::valid_username(username) || !account::exists(username)) {
             if (++input_attempt == 3) {
                 exceeds_attempt();
                 return std::make_pair(false, std::string{});

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -10,11 +10,6 @@
 #include <iostream>
 #include <string>
 #include <utility>
-#ifndef _WIN32
-#include <unistd.h>
-#else
-#include <Windows.h>
-#endif
 
 namespace login {
     static void exceeds_attempt() {
@@ -53,14 +48,8 @@ namespace login {
     }
 
     static auto valid_password(user const& other) {
-        user user{other.name};
-#ifdef _WIN32
-        utils::switchStdinEcho("ECHO_ON");
-        user.password = input::line(str::password);
-        utils::switchStdinEcho("ECHO_OFF");
-#else
-        user.password = getpass(str::password);
-#endif
+        user user{other.name, utils::read_password(str::password)};
+
         int input_attempt = 0;
         while (!account::valid_password(user)) {
             if (++input_attempt == 3) {
@@ -69,13 +58,7 @@ namespace login {
             }
 
             std::cout << user.name << str::ac_pass_incorrect;
-#ifdef _WIN32
-            utils::switchStdinEcho("ECHO_ON");
-            user.password = input::line(str::password);
-            utils::switchStdinEcho("ECHO_OFF");
-#else
-            user.password = getpass(str::password);
-#endif
+            user.password = utils::read_password(str::password);
         }
 
         return std::make_pair(true, user.password);

--- a/src/signup.cpp
+++ b/src/signup.cpp
@@ -10,11 +10,6 @@
 #include <iostream>
 #include <string>
 #include <utility>
-#ifndef _WIN32
-#include <unistd.h>
-#else
-#include <Windows.h>
-#endif
 
 namespace signup {
     static void exceeds_attempt() {
@@ -45,13 +40,7 @@ namespace signup {
     }
 
     std::pair<bool, std::string> valid_password() {
-#ifdef _WIN32
-        utils::switchStdinEcho("ECHO_ON");
-        std::string password = input::line(str::password);
-        utils::switchStdinEcho("ECHO_OFF");
-#else
-        std::string password = getpass(str::password);
-#endif
+        std::string password = utils::read_password(str::password);
 
         int input_attempt = 0;
         constexpr auto min_pass_len = 8;
@@ -62,13 +51,7 @@ namespace signup {
             }
 
             std::cout << str::min_pass_len << min_pass_len << "\n\n";
-#ifdef _WIN32
-            utils::switchStdinEcho("ECHO_ON");
-            password = input::line(str::password);
-            utils::switchStdinEcho("ECHO_OFF");
-#else
-            password = getpass(str::password);
-#endif
+            password = utils::read_password(str::password);
         }
 
         return {true, password};

--- a/src/signup.cpp
+++ b/src/signup.cpp
@@ -26,13 +26,18 @@ namespace signup {
         std::string username = input::line(str::username);
 
         int input_attempt = 0;
-        while (account::exists(username)) {
+        while (!account::valid_username(username) || account::exists(username)) {
             if (++input_attempt == 3) {
                 exceeds_attempt();
                 return std::make_pair(false, std::string{});
             }
 
-            std::cout << username << str::ac_already_exists;
+            if (!account::valid_username(username)) {
+                std::cout << str::invalid_username;
+            } else {
+                std::cout << username << str::ac_already_exists;
+            }
+
             username = input::line(str::username);
         }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,25 +1,62 @@
 #include "utils.h"
 
-#include <iostream>
+#include "input.h"
+
+#include <stdexcept>
 #include <string>
-#ifndef _WIN32
-#include <unistd.h>
-#else
+#ifdef _WIN32
 #include <Windows.h>
+#else
+#include <unistd.h>
 #endif
 
-namespace utils {
-    void switchStdinEcho(std::string const& console_mode) {
+namespace {
 #ifdef _WIN32
-        HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+    void set_console_echo(bool const enabled) {
+        HANDLE const stdin_handle = GetStdHandle(STD_INPUT_HANDLE);
+
         DWORD mode = 0;
-        GetConsoleMode(hStdin, &mode);
-        if (console_mode == "ECHO_ON") {
-            mode &= ~ENABLE_ECHO_INPUT;
-        } else {
-            mode |= ENABLE_ECHO_INPUT;
+        if (GetConsoleMode(stdin_handle, &mode) == 0) {
+            return;
         }
-        SetConsoleMode(hStdin, mode);
+
+        if (enabled) {
+            mode |= ENABLE_ECHO_INPUT;
+        } else {
+            mode &= ~ENABLE_ECHO_INPUT;
+        }
+
+        SetConsoleMode(stdin_handle, mode);
+    }
+
+    // The console is shared with the shell that launched Redux, so echo has to come back however
+    // the scope is left.
+    class echo_guard {
+    public:
+        echo_guard() { set_console_echo(false); }
+        ~echo_guard() { set_console_echo(true); }
+
+        echo_guard(echo_guard const&) = delete;
+        echo_guard& operator=(echo_guard const&) = delete;
+    };
+#endif
+} // namespace
+
+namespace utils {
+    std::string read_password(char const* const prompt) {
+#ifdef _WIN32
+        echo_guard const guard;
+
+        return input::line(prompt);
+#else
+        // getpass manages the terminal itself, and returns null when it cannot open /dev/tty --
+        // constructing a std::string from that would be undefined behaviour.
+        char const* const entered = getpass(prompt);
+        if (entered == nullptr) {
+            throw std::runtime_error{"could not read a password from the terminal"};
+        }
+
+        return entered;
 #endif
     }
 } // namespace utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+find_package(cryptopp CONFIG REQUIRED)
+
+# The storage layer only, without app.cpp -- the test provides its own main().
+add_executable(redux_tests
+  regression_tests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src/account.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src/file.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src/input.cpp
+)
+
+target_include_directories(redux_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_features(redux_tests PRIVATE cxx_std_17)
+target_link_libraries(redux_tests PRIVATE cryptopp::cryptopp)
+
+add_test(NAME redux_regression_tests COMMAND redux_tests)
+
+# The end-of-input cases fail by hanging rather than returning if they ever regress, so cap the
+# run instead of letting CI block on it.
+set_tests_properties(redux_regression_tests PROPERTIES TIMEOUT 120)

--- a/tests/regression_tests.cpp
+++ b/tests/regression_tests.cpp
@@ -1,0 +1,423 @@
+// Behavioural regression tests for Redux's storage layer.
+//
+// These link the real account.cpp / file.cpp and drive them against a throwaway HOME, so they
+// assert what the program actually does on disk rather than what the source looks like.
+// Every case here corresponds to a bug that was shipped at some point; they exist to stop it
+// coming back.
+//
+// POSIX only: the tests relocate the config directory by overriding HOME, which is how
+// file::user_files resolves it on POSIX but not on Windows.
+
+#include "account.h"
+#include "credential.h"
+#include "file.h"
+#include "input.h"
+#include "user.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+    int failures = 0;
+    int checks = 0;
+
+    void check(bool ok, std::string const& what) {
+        ++checks;
+        if (!ok) {
+            ++failures;
+            std::cout << "  FAIL  " << what << '\n';
+        } else {
+            std::cout << "  ok    " << what << '\n';
+        }
+    }
+
+    fs::path sandbox;
+
+    fs::path config_dir() { return sandbox / ".config" / "Redux"; }
+
+    void reset() {
+        // Restore permissions first; a test may have made the directory read-only.
+        std::error_code ec;
+        fs::permissions(config_dir(), fs::perms::owner_all, ec);
+        fs::remove_all(sandbox, ec);
+        fs::create_directories(sandbox);
+    }
+
+    std::string raw_bytes(fs::path const& p) {
+        std::ifstream in{p, std::ios::binary};
+        return std::string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+    }
+
+    void section(char const* name) { std::cout << "\n[" << name << "]\n"; }
+
+    std::string const pw = "correct-horse-battery";
+
+    // ---------------------------------------------------------------------
+
+    void usernames_that_could_escape_the_config_directory_are_rejected() {
+        section("username validation");
+
+        for (auto const& bad : {
+                 "",                    // empty
+                 "/etc/passwd",         // absolute: operator/ would discard the base directory
+                 "../../../.bashrc",    // traversal
+                 "sub/alice",           // separator: parent directory would not exist
+                 "sub\\alice",          // Windows separator
+                 ".last_user",          // collides with Redux's own state file
+                 ".",                   // current directory
+                 "..",                  // parent directory
+                 "alice$(whoami)",      // shell metacharacters
+                 "alice name",          // space
+             }) {
+            check(!account::valid_username(bad),
+                  std::string{"rejects \""} + bad + '"');
+        }
+
+        check(!account::valid_username(std::string(65, 'a')), "rejects a 65-character name");
+        check(account::valid_username(std::string(64, 'a')), "accepts a 64-character name");
+
+        for (auto const& good : {"alice", "Alice99", "alice_smith", "alice-smith", "alice.smith",
+                                 "a"}) {
+            check(account::valid_username(good), std::string{"accepts \""} + good + '"');
+        }
+    }
+
+    void a_failing_write_leaves_the_previous_vault_intact() {
+        section("writes are atomic and report failure");
+
+        if (geteuid() == 0) {
+            std::cout << "  skip  running as root, directory permissions would not be enforced\n";
+            return;
+        }
+
+        reset();
+        account::create(user{"alice", pw});
+
+        std::vector<credential> const creds{credential{"GitHub", "u@example.com", "gh-s3cret"}};
+        std::string const data = file::user_files::data("alice");
+        file::credentials::write(data, creds, pw);
+
+        std::string const before = raw_bytes(data);
+        check(!before.empty(), "vault written");
+
+        // Make the directory unwritable so the staging file cannot be created.
+        fs::permissions(config_dir(), fs::perms::owner_read | fs::perms::owner_exec);
+
+        bool threw = false;
+        try {
+            file::credentials::write(data, {credential{"Replacement", "x", "y"}}, pw);
+        } catch (std::exception const&) {
+            threw = true;
+        }
+
+        fs::permissions(config_dir(), fs::perms::owner_all);
+
+        check(threw, "a write that cannot succeed throws instead of failing silently");
+        check(raw_bytes(data) == before, "the previous vault is byte-for-byte intact");
+        check(fs::exists(data) && fs::file_size(data) > 0,
+              "the vault was never truncated to 0 bytes");
+
+        auto recovered = file::credentials::read(data, pw);
+        check(recovered.size() == 1 && recovered[0].password == "gh-s3cret",
+              "the original credential is still readable");
+    }
+
+    void no_staging_file_is_left_behind() {
+        section("no leftover staging files");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::credentials::write(file::user_files::data("alice"),
+                                 {credential{"GitHub", "u", "s"}}, pw);
+
+        bool leftover = false;
+        for (auto const& e : fs::directory_iterator{config_dir()}) {
+            if (e.path().extension() == ".new") {
+                leftover = true;
+            }
+        }
+        check(!leftover, "no '.new' staging file remains after a successful write");
+    }
+
+    void vault_files_are_not_readable_by_others() {
+        section("file permissions");
+
+        reset();
+        account::create(user{"alice", pw});
+
+        for (auto const& p : {file::user_files::account("alice"), file::user_files::data("alice")}) {
+            auto perms = fs::status(p).permissions();
+            check((perms & (fs::perms::group_all | fs::perms::others_all)) == fs::perms::none,
+                  fs::path{p}.filename().string() + " is owner-only");
+        }
+    }
+
+    void secrets_never_appear_in_cleartext_on_disk() {
+        section("vault contents are ciphertext");
+
+        reset();
+        account::create(user{"alice", pw});
+        std::string const data = file::user_files::data("alice");
+        file::credentials::write(
+            data, {credential{"GitHub", "alice@example.com", "gh-s3cret-token"}}, pw);
+
+        auto const bytes = raw_bytes(data);
+        for (auto const& secret : {"gh-s3cret-token", "alice@example.com", "GitHub", pw.c_str()}) {
+            check(bytes.find(secret) == std::string::npos,
+                  std::string{"vault does not contain \""} + secret + "\" in cleartext");
+        }
+        check(raw_bytes(file::user_files::account("alice")).find(pw) == std::string::npos,
+              "account file does not contain the master password");
+    }
+
+    void a_wrong_password_does_not_lock_the_account_out() {
+        section("failed attempts leave no state behind");
+
+        reset();
+        account::create(user{"alice", pw});
+
+        check(account::valid_password(user{"alice", pw}), "correct password accepted");
+        for (int i = 0; i < 5; ++i) {
+            check(!account::valid_password(user{"alice", "wrong"}), "wrong password rejected");
+        }
+        check(account::valid_password(user{"alice", pw}),
+              "correct password still accepted after repeated failures");
+    }
+
+    void changing_the_password_re_encrypts_the_vault() {
+        section("change_password");
+
+        reset();
+        account::create(user{"alice", pw});
+        std::string const data = file::user_files::data("alice");
+        file::credentials::write(data, {credential{"GitHub", "u", "gh-s3cret"}}, pw);
+
+        std::string const newpw = "a-brand-new-passphrase";
+        account::change_password(user{"alice", pw}, newpw);
+
+        check(!account::valid_password(user{"alice", pw}), "old password no longer works");
+        check(account::valid_password(user{"alice", newpw}), "new password works");
+
+        auto after = file::credentials::read(data, newpw);
+        check(after.size() == 1 && after[0].password == "gh-s3cret",
+              "vault readable under the new password, contents intact");
+
+        bool old_fails = false;
+        try {
+            (void)file::credentials::read(data, pw);
+        } catch (std::exception const&) {
+            old_fails = true;
+        }
+        check(old_fails, "vault not readable under the old password");
+    }
+
+    void changing_the_password_with_no_vault_does_not_throw() {
+        section("change_password with an absent vault");
+
+        reset();
+        account::create(user{"alice", pw});
+        fs::remove(file::user_files::data("alice"));
+
+        bool threw = false;
+        try {
+            account::change_password(user{"alice", pw}, "a-brand-new-passphrase");
+        } catch (std::exception const&) {
+            threw = true;
+        }
+        check(!threw, "an absent vault is handled rather than aborting the program");
+        check(account::valid_password(user{"alice", "a-brand-new-passphrase"}),
+              "the password change still took effect");
+    }
+
+    void the_remembered_username_holds_no_secret() {
+        section("remembered username");
+
+        reset();
+        file::last_user::save("alice");
+        check(file::last_user::load() == "alice", "remembered username round-trips");
+
+        auto const p = config_dir() / ".last_user";
+        check(raw_bytes(p) == "alice", "file contains exactly the username");
+        check(raw_bytes(p).find(pw) == std::string::npos, "file contains no password");
+
+        auto perms = fs::status(p).permissions();
+        check((perms & (fs::perms::group_all | fs::perms::others_all)) == fs::perms::none,
+              ".last_user is owner-only");
+    }
+
+    // Two accounts must never map onto each other's files. Both of these were real collisions:
+    // "alice_data" took over "alice"'s vault under the old suffix, and "alice.new" collided with
+    // the staging file used while saving "alice".
+    void one_account_cannot_overwrite_another() {
+        section("account file paths cannot collide");
+
+        reset();
+
+        // Names chosen to probe every string Redux derives from "alice": the vault suffix and the
+        // staging name used while writing a file. Each of these is a name a user can register.
+        std::vector<std::string> const neighbours{"alice_data", "alice.new", "alice.vault",
+                                                  "alice_datavault"};
+        std::string const npw = "neighbour-password";
+
+        account::create(user{"alice", pw});
+        file::credentials::write(file::user_files::data("alice"),
+                                 {credential{"GitHub", "u", "alice-secret"}}, pw);
+
+        for (auto const& n : neighbours) {
+            check(account::valid_username(n), n + " is a name a user could register");
+            account::create(user{n, npw});
+            file::credentials::write(file::user_files::data(n),
+                                     {credential{"Site", "u", n + "-secret"}}, npw);
+        }
+
+        // Every derived path must be distinct.
+        std::vector<std::string> paths{file::user_files::account("alice"),
+                                       file::user_files::data("alice")};
+        for (auto const& n : neighbours) {
+            paths.push_back(file::user_files::account(n));
+            paths.push_back(file::user_files::data(n));
+        }
+        std::sort(paths.begin(), paths.end());
+        check(std::adjacent_find(paths.begin(), paths.end()) == paths.end(),
+              "no two account or vault paths are identical");
+
+        // Rewrite alice's files now that the neighbours exist. This is the moment a colliding
+        // suffix or staging name does its damage: staging is created and then renamed away, so it
+        // would take a neighbour's file with it.
+        account::change_password(user{"alice", pw}, pw);
+        file::credentials::write(file::user_files::data("alice"),
+                                 {credential{"GitHub", "u", "alice-secret"}}, pw);
+
+        check(account::valid_password(user{"alice", pw}), "alice's account still works");
+        auto alice_creds = file::credentials::read(file::user_files::data("alice"), pw);
+        check(alice_creds.size() == 1 && alice_creds[0].password == "alice-secret",
+              "alice's vault is intact");
+
+        for (auto const& n : neighbours) {
+            check(account::valid_password(user{n, npw}),
+                  n + "'s account survived writes to alice");
+            std::vector<credential> c;
+            try {
+                c = file::credentials::read(file::user_files::data(n), npw);
+            } catch (std::exception const&) {
+                // leave c empty; the check below reports it
+            }
+            check(c.size() == 1 && c[0].password == n + "-secret", n + "'s vault is intact");
+        }
+    }
+
+    // An exhausted stdin used to make input::choice spin forever: clear() followed by ignore()
+    // re-set eofbit immediately, so it printed the retry message without bound (93 MB in three
+    // seconds, measured). Each of these must terminate by throwing.
+    //
+    // If this regresses, the functions loop instead of returning, so the test hangs rather than
+    // failing -- the ctest TIMEOUT in tests/CMakeLists.txt is what turns that into a red build.
+    void exhausted_stdin_terminates_instead_of_spinning() {
+        section("end of input");
+
+        auto with_empty_stdin = [](auto&& fn) {
+            std::istringstream empty;
+            std::ostringstream discard;
+            auto* old_in = std::cin.rdbuf(empty.rdbuf());
+            auto* old_out = std::cout.rdbuf(discard.rdbuf());
+
+            bool threw = false;
+            try {
+                fn();
+            } catch (input::end_of_input const&) {
+                threw = true;
+            } catch (...) {
+                // any other exception counts as "did not spin", but not as correct
+            }
+
+            std::cin.rdbuf(old_in);
+            std::cout.rdbuf(old_out);
+            return threw;
+        };
+
+        check(with_empty_stdin([] { (void)input::choice("choice: "); }),
+              "choice() throws end_of_input rather than looping");
+        check(with_empty_stdin([] { (void)input::line("line: "); }),
+              "line() throws end_of_input rather than returning junk");
+        check(with_empty_stdin([] { (void)input::line_or("line_or: ", "fallback"); }),
+              "line_or() throws end_of_input rather than silently accepting the default");
+    }
+
+    void nothing_on_disk_grants_a_session() {
+        section("no credential-free session state");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::last_user::save("alice");
+
+        bool found = false;
+        for (auto const& e : fs::recursive_directory_iterator{sandbox}) {
+            auto const name = e.path().filename().string();
+            if (name == "do_not_open") {
+                found = true;
+            }
+        }
+        check(!found, "no 'do_not_open' style session file is created");
+    }
+
+} // namespace
+
+int main() {
+    sandbox = fs::temp_directory_path() / "redux-regression-tests";
+    reset();
+    setenv("HOME", sandbox.c_str(), 1);
+
+    // Each case is run under its own handler so an unexpected exception is reported as a failure
+    // rather than aborting the process and hiding which case broke.
+    struct testcase {
+        char const* name;
+        void (*run)();
+    };
+
+    for (auto const& tc : {
+             testcase{"username validation",
+                      usernames_that_could_escape_the_config_directory_are_rejected},
+             testcase{"atomic writes", a_failing_write_leaves_the_previous_vault_intact},
+             testcase{"staging cleanup", no_staging_file_is_left_behind},
+             testcase{"file permissions", vault_files_are_not_readable_by_others},
+             testcase{"ciphertext at rest", secrets_never_appear_in_cleartext_on_disk},
+             testcase{"no lockout", a_wrong_password_does_not_lock_the_account_out},
+             testcase{"change_password", changing_the_password_re_encrypts_the_vault},
+             testcase{"change_password, no vault", changing_the_password_with_no_vault_does_not_throw},
+             testcase{"remembered username", the_remembered_username_holds_no_secret},
+             testcase{"path collisions", one_account_cannot_overwrite_another},
+             testcase{"end of input", exhausted_stdin_terminates_instead_of_spinning},
+             testcase{"no session state", nothing_on_disk_grants_a_session},
+         }) {
+        try {
+            tc.run();
+        } catch (std::exception const& e) {
+            ++checks;
+            ++failures;
+            std::cout << "  FAIL  " << tc.name << " threw unexpectedly: " << e.what() << '\n';
+        }
+    }
+
+    std::error_code ec;
+    fs::permissions(config_dir(), fs::perms::owner_all, ec);
+    fs::remove_all(sandbox, ec);
+
+    std::cout << "\n" << (checks - failures) << "/" << checks << " checks passed\n";
+    if (failures != 0) {
+        std::cout << failures << " FAILED\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

Five defects found by auditing current `main`. Each was reproduced against a built binary before being fixed, and each now has a test. Backward compatibility with existing on-disk data is deliberately **not** preserved — see [Effect on existing data](#effect-on-existing-data).

### 1. Writes were silent and destructive on failure

`write_encrypted` opened the target with `trunc`, destroying the old contents *before* the new bytes were known to be written, and never checked the result. A failing write therefore left a **0-byte vault**, which then threw on every subsequent read — an account bricked with no way in and no error ever shown.

It now stages the ciphertext in a sibling temp file, checks the stream, and renames over the target. The previous vault survives any failure, a partial vault cannot exist, and failures throw instead of returning `void`. The staging file is made owner-only before publication, which also stops vault files being created world-readable.

### 2. Nothing caught exceptions

`main()` had no handler, so a corrupt vault aborted the process:

```
libc++abi: terminating due to uncaught exception of type CryptoPP::KeyBadErr
```

It now reports the error and returns 1:

```
Redux stopped: DataDecryptor: cannot decrypt message with this passphrase
```

### 3. An exhausted stdin spun forever

`input::choice` called `clear()` then `ignore()`, which re-set `eofbit` immediately. Measured: **93,162,737 bytes of output and 2,025,273 retry messages in three seconds**, reachable with Ctrl-D at any menu or any redirected stdin. Input functions now throw `input::end_of_input`, which `main` turns into a clean exit (180 bytes, exit 0).

### 4. Usernames were unvalidated and became filenames directly

Signing up as `sub/alice` made every write fail silently — signup appeared to succeed, credentials appeared to save, and nothing but `.last_user` reached disk. On relaunch the account did not exist and the data was gone. Absolute names like `/etc/passwd` discarded the base directory entirely (`operator/` replaces on an absolute right operand), and `../../..` escaped it.

`account::valid_username` now requires an alphanumeric first character and permits only alphanumerics, `.`, `-` and `_`, up to 64 characters — checked before any path is derived from a username, at both signup and login. Requiring an alphanumeric first character also makes Redux's own dot-prefixed state files unreachable, which removes the `.last_user` collision.

### 5. Account file paths could collide

The old `_data` vault suffix meant registering **`alice_data` took over `alice`'s vault**. And the staging file introduced by fix 1 would have collided with a user named **`alice.new`**, whose account file it would clobber and then rename away. The vault suffix is now `@vault` (`@` cannot occur in a valid username) and staging names are dot-prefixed, so neither can ever name another account's file.

Separately, `change_password` called `crypt` directly and threw where `credentials::read` would not; it now goes through the same layer.

## Tests

`tests/regression_tests.cpp` — 67 checks against the real `account.cpp` / `file.cpp` / `input.cpp`, run by `ctest` in the Ubuntu workflow. This is the first test in this repo that asserts behaviour rather than grepping source text.

It has a `TIMEOUT` because the end-of-input cases fail by *hanging* rather than returning if they regress, and a hang would otherwise block CI rather than fail it.

Every fix was **mutation-tested** — reverting it must make the suite fail:

| Mutation | Result |
|---|---|
| vault suffix back to `_data` | fails: "no two account or vault paths are identical" |
| staging name back to `<file>.new` | fails: "alice.new's account survived writes to alice" |
| remove the `eof()` guard in `choice` | hangs → hits the ctest TIMEOUT → red build |
| (first draft of the collision test) | **passed both mutations** — it was worthless, and was rewritten |

That last row is why the mutation step exists: the original collision test created its neighbour accounts *after* the last write to `alice`, so the transient staging clobber never happened, and it never registered `alice_data` at all.

## Effect on existing data

The vault suffix changed, so **a vault written by an earlier version is no longer found and the account will present as empty**. The old `<user>_data` file is orphaned rather than deleted and can be recovered by renaming it to `<user>@vault`. This is intentional given the decision not to carry compatibility forward.

## Still open

Not addressed here: the plaintext CSV export (now the only path that puts plaintext on disk), the KDF (`DefaultEncryptorWithMAC` is AES-128 + SHA-256 + HMAC-SHA256 with an 8-byte salt but only **2500** iterations), secrets not scrubbed from memory, `getpass` returning `NULL` being UB, `feature::remove` silently reordering positional IDs, no `CMAKE_BUILD_TYPE` on the Linux/macOS artifacts, no `-Wall -Wextra`, and `.clang-tidy` never running. Also: **CodeQL did not run on PR #19** despite declaring `pull_request: [main]`, likely a missing `permissions: security-events: write`.

`write_encrypted` still does not `fsync` before the rename, so the change protects against failed writes and process death but not against power loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
