### PR TITLE
Rework vault security: encrypted envelope format, atomicity, locking, CI hardening

### DIFF
--- a/.github/workflows/Linux-release.yml
+++ b/.github/workflows/Linux-release.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7.0.1
+    # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
+    # not fetch on its own -- without this, resolving the pinned versions database fails.
+    - name: fetch vcpkg baseline
+      run: sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         sudo apt install g++-11

--- a/.github/workflows/Linux-release.yml
+++ b/.github/workflows/Linux-release.yml
@@ -7,10 +7,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.1
     - name: build
       run: |
-        vcpkg install cryptopp
         sudo apt install g++-11
         g++ --version
         mkdir build
@@ -22,7 +21,7 @@ jobs:
     - name: strip
       run: strip build/src/Redux
     - name: Upload Ubuntu Application
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: Linux-Application
         path: /home/runner/work/Redux/Redux/build/src/Redux

--- a/.github/workflows/Linux-release.yml
+++ b/.github/workflows/Linux-release.yml
@@ -17,6 +17,9 @@ jobs:
         # --force: the image ships the clone with local edits that a plain checkout refuses
         # to overwrite; the runner is ephemeral, so discarding them is fine.
         sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
+        # The image's vcpkg binary predates the checked-out tree's tool schema; re-bootstrap so
+        # the tool matches the tree it now runs against.
+        sudo /usr/local/share/vcpkg/bootstrap-vcpkg.sh
     - name: build
       run: |
         sudo apt install g++-11

--- a/.github/workflows/Linux-release.yml
+++ b/.github/workflows/Linux-release.yml
@@ -9,9 +9,12 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
-    # not fetch on its own -- without this, resolving the pinned versions database fails.
-    - name: fetch vcpkg baseline
-      run: sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+    # not fetch on its own. Fetching alone is not enough either: vcpkg reads the versions
+    # database and ports from the checked-out tree, so the baseline has to be checked out too.
+    - name: pin vcpkg to the manifest baseline
+      run: |
+        sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         sudo apt install g++-11

--- a/.github/workflows/Linux-release.yml
+++ b/.github/workflows/Linux-release.yml
@@ -14,7 +14,9 @@ jobs:
     - name: pin vcpkg to the manifest baseline
       run: |
         sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
-        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
+        # --force: the image ships the clone with local edits that a plain checkout refuses
+        # to overwrite; the runner is ephemeral, so discarding them is fine.
+        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         sudo apt install g++-11

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4.37.4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,6 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - run: |
-        vcpkg install cryptopp
         sudo apt install g++-10
         mkdir build
         cd build
@@ -63,4 +62,4 @@ jobs:
 
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4.37.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,9 +38,12 @@ jobs:
       uses: actions/checkout@v7.0.1
 
     # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
-    # not fetch on its own -- without this, resolving the pinned versions database fails.
-    - name: fetch vcpkg baseline
-      run: sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+    # not fetch on its own. Fetching alone is not enough either: vcpkg reads the versions
+    # database and ports from the checked-out tree, so the baseline has to be checked out too.
+    - name: pin vcpkg to the manifest baseline
+      run: |
+        sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,9 @@ jobs:
     - name: pin vcpkg to the manifest baseline
       run: |
         sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
-        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
+        # --force: the image ships the clone with local edits that a plain checkout refuses
+        # to overwrite; the runner is ephemeral, so discarding them is fine.
+        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7.0.1
 
+    # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
+    # not fetch on its own -- without this, resolving the pinned versions database fails.
+    - name: fetch vcpkg baseline
+      run: sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4.37.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,9 @@ jobs:
         # --force: the image ships the clone with local edits that a plain checkout refuses
         # to overwrite; the runner is ephemeral, so discarding them is fine.
         sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
+        # The image's vcpkg binary predates the checked-out tree's tool schema; re-bootstrap so
+        # the tool matches the tree it now runs against.
+        sudo /usr/local/share/vcpkg/bootstrap-vcpkg.sh
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/macOS-release.yml
+++ b/.github/workflows/macOS-release.yml
@@ -17,6 +17,9 @@ jobs:
         # --force: the image ships the clone with local edits that a plain checkout refuses
         # to overwrite; the runner is ephemeral, so discarding them is fine.
         sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
+        # The image's vcpkg binary predates the checked-out tree's tool schema; re-bootstrap so
+        # the tool matches the tree it now runs against.
+        sudo /usr/local/share/vcpkg/bootstrap-vcpkg.sh
     - name: build
       run: |
         mkdir build

--- a/.github/workflows/macOS-release.yml
+++ b/.github/workflows/macOS-release.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7.0.1
+    # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
+    # not fetch on its own -- without this, resolving the pinned versions database fails.
+    - name: fetch vcpkg baseline
+      run: sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         mkdir build

--- a/.github/workflows/macOS-release.yml
+++ b/.github/workflows/macOS-release.yml
@@ -9,9 +9,12 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
-    # not fetch on its own -- without this, resolving the pinned versions database fails.
-    - name: fetch vcpkg baseline
-      run: sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+    # not fetch on its own. Fetching alone is not enough either: vcpkg reads the versions
+    # database and ports from the checked-out tree, so the baseline has to be checked out too.
+    - name: pin vcpkg to the manifest baseline
+      run: |
+        sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         mkdir build

--- a/.github/workflows/macOS-release.yml
+++ b/.github/workflows/macOS-release.yml
@@ -7,17 +7,18 @@ jobs:
     runs-on: macos-26
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.1
     - name: build
       run: |
-        vcpkg install cryptopp:arm64-osx
         mkdir build
         cd build
         cmake .. -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
         cmake --build .
         strip src/Redux
+    - name: test
+      run: ctest --test-dir build --output-on-failure
     - name: Upload macOS Application
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: macOS Application
         path: /Users/runner/work/Redux/Redux/build/src/Redux

--- a/.github/workflows/macOS-release.yml
+++ b/.github/workflows/macOS-release.yml
@@ -14,7 +14,9 @@ jobs:
     - name: pin vcpkg to the manifest baseline
       run: |
         sudo git -C /usr/local/share/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
-        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
+        # --force: the image ships the clone with local edits that a plain checkout refuses
+        # to overwrite; the runner is ephemeral, so discarding them is fine.
+        sudo git -C /usr/local/share/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         mkdir build

--- a/.github/workflows/win-release32.yml
+++ b/.github/workflows/win-release32.yml
@@ -7,14 +7,15 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.1
     - name: build
       run: |
-        vcpkg install cryptopp:x86-windows
         cmake -G "Visual Studio 17 2022" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
         cmake --build build32 --config Release
+    - name: test
+      run: ctest --test-dir build32 -C Release --output-on-failure
     - name: Upload Windows Application
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: Windows-Applicationx86
         path: D:\a\Redux\Redux\build32\src\Release\Redux.exe

--- a/.github/workflows/win-release32.yml
+++ b/.github/workflows/win-release32.yml
@@ -17,6 +17,9 @@ jobs:
         # --force: the image ships the clone with local edits that a plain checkout refuses
         # to overwrite; the runner is ephemeral, so discarding them is fine.
         git -C C:/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
+        # The image's vcpkg binary predates the checked-out tree's tool schema; re-bootstrap so
+        # the tool matches the tree it now runs against.
+        C:/vcpkg/bootstrap-vcpkg.bat
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/win-release32.yml
+++ b/.github/workflows/win-release32.yml
@@ -9,9 +9,12 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
-    # not fetch on its own -- without this, resolving the pinned versions database fails.
-    - name: fetch vcpkg baseline
-      run: git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+    # not fetch on its own. Fetching alone is not enough either: vcpkg reads the versions
+    # database and ports from the checked-out tree, so the baseline has to be checked out too.
+    - name: pin vcpkg to the manifest baseline
+      run: |
+        git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+        git -C C:/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/win-release32.yml
+++ b/.github/workflows/win-release32.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7.0.1
+    # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
+    # not fetch on its own -- without this, resolving the pinned versions database fails.
+    - name: fetch vcpkg baseline
+      run: git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/win-release32.yml
+++ b/.github/workflows/win-release32.yml
@@ -14,7 +14,9 @@ jobs:
     - name: pin vcpkg to the manifest baseline
       run: |
         git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
-        git -C C:/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
+        # --force: the image ships the clone with local edits that a plain checkout refuses
+        # to overwrite; the runner is ephemeral, so discarding them is fine.
+        git -C C:/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/win-release64.yml
+++ b/.github/workflows/win-release64.yml
@@ -9,9 +9,12 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
-    # not fetch on its own -- without this, resolving the pinned versions database fails.
-    - name: fetch vcpkg baseline
-      run: git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+    # not fetch on its own. Fetching alone is not enough either: vcpkg reads the versions
+    # database and ports from the checked-out tree, so the baseline has to be checked out too.
+    - name: pin vcpkg to the manifest baseline
+      run: |
+        git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
+        git -C C:/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/win-release64.yml
+++ b/.github/workflows/win-release64.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7.0.1
+    # The image's bundled vcpkg clone predates the manifest's builtin-baseline, and vcpkg does
+    # not fetch on its own -- without this, resolving the pinned versions database fails.
+    - name: fetch vcpkg baseline
+      run: git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/win-release64.yml
+++ b/.github/workflows/win-release64.yml
@@ -7,14 +7,15 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.1
     - name: build
       run: |
-        vcpkg install cryptopp:x64-windows
         cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
         cmake --build build64 --config Release
+    - name: test
+      run: ctest --test-dir build64 -C Release --output-on-failure
     - name: Upload Windows Application
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: Windows-Applicationx64
         path: D:\a\Redux\Redux\build64\src\Release\Redux.exe

--- a/.github/workflows/win-release64.yml
+++ b/.github/workflows/win-release64.yml
@@ -14,7 +14,9 @@ jobs:
     - name: pin vcpkg to the manifest baseline
       run: |
         git -C C:/vcpkg fetch origin 25b93347d8b1cb83bba83899c85455de050b8d02
-        git -C C:/vcpkg -c advice.detachedHead=false checkout 25b93347d8b1cb83bba83899c85455de050b8d02
+        # --force: the image ships the clone with local edits that a plain checkout refuses
+        # to overwrite; the runner is ephemeral, so discarding them is fine.
+        git -C C:/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/.github/workflows/win-release64.yml
+++ b/.github/workflows/win-release64.yml
@@ -17,6 +17,9 @@ jobs:
         # --force: the image ships the clone with local edits that a plain checkout refuses
         # to overwrite; the runner is ephemeral, so discarding them is fine.
         git -C C:/vcpkg -c advice.detachedHead=false checkout --force 25b93347d8b1cb83bba83899c85455de050b8d02
+        # The image's vcpkg binary predates the checked-out tree's tool schema; re-bootstrap so
+        # the tool matches the tree it now runs against.
+        C:/vcpkg/bootstrap-vcpkg.bat
     - name: build
       run: |
         cmake -G "Visual Studio 17 2022" -A x64 -S . -B "build64" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,9 @@ project(
 
 add_subdirectory(src)
 
-# The regression tests relocate the config directory by overriding HOME, which is how the POSIX
-# build resolves it. The Windows build uses GetUserProfileDirectory instead, so they are not
-# portable as written.
-if(NOT WIN32)
-  enable_testing()
-  add_subdirectory(tests)
-endif()
+# The regression tests used to relocate the config directory by overriding HOME, which the
+# Windows build never consults (it resolves the profile directory via the Win32 API instead), so
+# tests were POSIX-only. They now relocate storage via REDUX_CONFIG_DIR, which every platform
+# checks first, so the suite runs everywhere.
+enable_testing()
+add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A cross-platform Application for storing User-Data.
 ## Building The App from Source(Linux): 🔨
 ### Prerequisites:
     
-* CMake >= 3.1 <br>
+* CMake >= 3.22 <br>
 * g++ >= 8 (CXX standard=17) <br>
 * [vcpkg](https://github.com/microsoft/vcpkg)
 
@@ -16,21 +16,20 @@ A cross-platform Application for storing User-Data.
 ```
 ./bootstrap-vcpkg.sh
 ```
-2. To install the libraries for your project, run the below command in the root directory of vcpkg: 
-```bash
-./vcpkg install cryptopp
-```
-3. Download Redux and run this command assuming vcpkg is installed in ``` home/username/Repos/vcpkg ``` and Redux is located ``` /home/username/Repos/Redux/ ```
+2. Download Redux and run this command assuming vcpkg is installed in ``` home/username/Repos/vcpkg ``` and Redux is located ``` /home/username/Repos/Redux/ ```
 
 ```
 cmake -B /home/username/Repos/Redux/build -S . -DCMAKE_TOOLCHAIN_FILE=/home/username/Repos/vcpkg/scripts/buildsystems/vcpkg.cmake
 ```
 
-4. To compile the project run:
+Redux ships a `vcpkg.json` manifest, so the toolchain file installs Crypto++ itself at configure
+time -- there is no separate `vcpkg install` step to run first.
+
+3. To compile the project run:
 ```
 cmake --build /home/username/Repos/Redux/build
 ```
-5. Run The Executable:
+4. Run The Executable:
 ``` 
 ./build/src/Redux
 ```
@@ -40,31 +39,44 @@ cmake --build /home/username/Repos/Redux/build
 ## Building The App from Source(Windows): 🔨
 ### Prerequisites:
     
-* CMake >= 3.1 
-* Microsoft Visual Studio 2019
+* CMake >= 3.22 
+* Microsoft Visual Studio 2022 (v17) -- matches the compiler CI builds with
 * [vcpkg](https://github.com/microsoft/vcpkg)
 
 ### Steps:
 1. Download [vcpkg](https://github.com/microsoft/vcpkg) and run ```/bootstrap-vcpkg.bat```
 
-2. For installing required modules, run one of these commands in the root directory of vcpkg:
-
-    * ```vcpkg install cryptopp:x64-windows``` (For 64-bit PC)
-    * ```vcpkg install cryptopp:x86-windows``` (For 32-bit PC)
-
-3. Opening cmd in root directory of Redux, and run these commands assuming your vcpkg is installed in ```C://vcpkg``` and Redux is located in ```D:\Repos\Redux```:
+2. Opening cmd in root directory of Redux, and run these commands assuming your vcpkg is installed in ```C://vcpkg``` and Redux is located in ```D:\Repos\Redux```:
     ```
-    cmake -G "Visual Studio 16 2019" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+    cmake -G "Visual Studio 17 2022" -A Win32 -S . -B "build32" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
     cmake --build build32 --config Release
     ```
 
-4. Binaries will be at ```D:\Repos\Redux\build32\src\Release\Redux.exe```
+    As on Linux, the `vcpkg.json` manifest is what pulls in Crypto++ -- the toolchain file installs
+    it (for whichever triplet CMake is configuring) during the first command above, so there is no
+    `vcpkg install cryptopp:...` step to run separately.
+
+3. Binaries will be at ```D:\Repos\Redux\build32\src\Release\Redux.exe```
 
 ## Notes (if using Pre-Build Binaries for Windows):
 
-1. Please Install **Microsoft Visual C++ Redistributable for Visual Studio 2019** before running binaries:
-    1. For [x64](https://aka.ms/vs/16/release/VC_redist.x64.exe),
-    2. For [x86](https://aka.ms/vs/16/release/VC_redist.x86.exe),
-    3. For [ARM64](https://aka.ms/vs/16/release/VC_redist.arm64.exe).
+1. Please Install **Microsoft Visual C++ Redistributable for Visual Studio 2022** before running binaries:
+    1. For [x64](https://aka.ms/vs/17/release/VC_redist.x64.exe),
+    2. For [x86](https://aka.ms/vs/17/release/VC_redist.x86.exe),
+    3. For [ARM64](https://aka.ms/vs/17/release/VC_redist.arm64.exe).
 
-2. The last thing is simply a matter of ***perception***. If you are running any sort of anti-virus, like ***ZoneAlarm, Norton, McAfee, etc***. then they will get a very unpleasant message about your program trying to do something considered ***dangerous***. It may be due to ***system(); function*** used in program. Read more about it [here](http://www.cplusplus.com/reference/cstdlib/system/) and [here](http://www.cplusplus.com/articles/j3wTURfi/)
+## Testing
+
+```
+ctest --test-dir build --output-on-failure
+```
+
+The regression suite never touches a developer's real config directory: it relocates storage by
+setting `REDUX_CONFIG_DIR`, which every build of Redux -- not just the tests -- checks before
+falling back to the platform default.
+
+## Vault format
+
+Vaults are encrypted with scrypt-derived AES-256-GCM keys. The on-disk format is versioned, and
+this is a deliberate break: vaults written by pre-rework versions of Redux are not readable by
+this version, and there is no migration path.

--- a/include/account.h
+++ b/include/account.h
@@ -1,11 +1,20 @@
 #ifndef ACCOUNT_H
 #define ACCOUNT_H
 
+#include <stdexcept>
 #include <string>
 
 struct user;
 
 namespace account {
+    // Thrown by create() when a current-format vault already exists for the username. create()
+    // always runs under the account lock, so this recheck is what actually closes the signup
+    // race: two processes can both see a name as free before either creates it, and without
+    // this the loser would silently replace the winner's vault with its own password.
+    struct already_exists : std::runtime_error {
+        explicit already_exists(std::string const& username);
+    };
+
     // A username becomes a filename, so it must not be able to alter the path it builds. Rejects
     // separators, traversal, absolute paths, and names that could collide with Redux's own state
     // files. Check this before any path is derived from a username.
@@ -19,6 +28,8 @@ namespace account {
     // password.
     bool valid_password(user const&);
 
+    // Throws already_exists rather than replacing a vault that appeared since the caller's
+    // availability check. Must be called holding the account lock.
     void create(user const&);
 
     // Reads the vault under the old password and writes it once under the new one: a single

--- a/include/account.h
+++ b/include/account.h
@@ -12,8 +12,19 @@ namespace account {
     bool valid_username(std::string const& username);
 
     bool exists(std::string const& username);
+
+    // Returns false only for a wrong password (indistinguishable from a tampered vault -- see
+    // file::vault::read). Any other failure -- I/O errors, an unsupported vault format, a vault
+    // whose recorded username does not match -- propagates instead of being reported as a wrong
+    // password.
     bool valid_password(user const&);
+
     void create(user const&);
+
+    // Reads the vault under the old password and writes it once under the new one: a single
+    // atomic replace. The former two-file design wrote the account file and the vault file
+    // independently, so an interruption between the two could strand the account on mismatched
+    // passwords; there is only one file now, so there is nothing left to strand.
     void change_password(user const&, std::string const& password);
 } // namespace account
 

--- a/include/file.h
+++ b/include/file.h
@@ -1,25 +1,47 @@
 #ifndef FILE_H
 #define FILE_H
 
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 struct credential;
 
-namespace file::credentials {
-    void write(std::string const& filename, std::vector<credential> const&,
+// One file per account, at config_dir()/<username>, holding every credential the account owns,
+// encrypted under the master password. There is no separate account file any more -- the old
+// design wrote that file and the vault file independently, so an interruption between the two
+// writes (most visibly during change_password) could strand the account on mismatched passwords.
+namespace file::vault {
+    void write(std::string const& username, std::vector<credential> const& credentials,
                std::string const& password);
-    std::vector<credential> read(std::string const& filename, std::string const& password);
-} // namespace file::credentials
+
+    // Throws CryptoPP::HashVerificationFilter::HashVerificationFailed for a wrong password or a
+    // tampered ciphertext/header (the two are cryptographically indistinguishable -- see
+    // account::valid_password, which relies on that being the only exception with this meaning).
+    // Throws std::runtime_error for anything else that makes the file untrustworthy: a missing
+    // file, an unrecognized header (not a Redux vault, or scrypt parameters outside the range
+    // this build accepts), or a plaintext username that does not match `username` (the file was
+    // renamed onto, or substituted for, this account's).
+    std::vector<credential> read(std::string const& username, std::string const& password);
+
+    bool exists(std::string const& username);
+    std::filesystem::path path(std::string const& username);
+} // namespace file::vault
 
 namespace file::users {
-    void writeToCSV(std::string filename, credential const& user_credentials, int const number);
+    // Builds the whole file in memory and publishes it through the same atomic, owner-only write
+    // used by the vault (see write_file_atomic in file.cpp), so a failing export cannot leave a
+    // half-written CSV behind. Every field is quoted and OWASP CSV-injection characters are
+    // neutralized -- see file.cpp.
+    void writeToCSV(std::string const& filename, std::vector<credential> const& credentials);
 } // namespace file::users
 
 namespace file::user_files {
+    // Base path for files Redux derives from a username but that are not the vault itself --
+    // currently only the CSV export.
     std::string filePath(std::string const& username);
-    std::string data(std::string const& username);
-    std::string account(std::string const& username);
 } // namespace file::user_files
 
 // Remembers who logged in last so the login prompt can offer it as a default. Stores the
@@ -29,14 +51,35 @@ namespace file::last_user {
     std::string load();
 } // namespace file::last_user
 
-namespace file::crypt {
-    // Encrypts `plaintext` under `password` and writes the ciphertext to `filename`.
-    void write_encrypted(std::string const& filename, std::string const& plaintext,
-                         std::string const& password);
+namespace file {
 
-    // Returns the plaintext of `filename`. Throws if the file is missing or unreadable, or if
-    // `password` is wrong -- the MAC makes a wrong password indistinguishable from corruption.
-    std::string read_decrypted(std::string const& filename, std::string const& password);
-} // namespace file::crypt
+    // Thrown when a second Redux instance already holds the lock on this account.
+    struct account_busy : std::runtime_error {
+        explicit account_busy(std::string const& username);
+    };
+
+    // Held for the duration of a session -- login or signup, through after_signin_services::run
+    // -- so a second Redux instance cannot interleave a read-modify-write cycle (most visibly
+    // change_password) against the same account. Acquired non-blocking: construction throws
+    // account_busy immediately rather than waiting for the other instance to finish. Move-only;
+    // the lock file itself is never deleted, only the lock held on it is released, on
+    // destruction -- deleting it would reopen the race between the delete and a concurrent
+    // acquisition by another instance.
+    class account_lock {
+    public:
+        explicit account_lock(std::string const& username);
+        ~account_lock();
+
+        account_lock(account_lock const&) = delete;
+        account_lock& operator=(account_lock const&) = delete;
+        account_lock(account_lock&&) noexcept;
+        account_lock& operator=(account_lock&&) noexcept;
+
+    private:
+        struct impl;
+        std::unique_ptr<impl> impl_;
+    };
+
+} // namespace file
 
 #endif // FILE_H

--- a/include/file.h
+++ b/include/file.h
@@ -39,9 +39,12 @@ namespace file::users {
 } // namespace file::users
 
 namespace file::user_files {
-    // Base path for files Redux derives from a username but that are not the vault itself --
-    // currently only the CSV export.
-    std::string filePath(std::string const& username);
+    // Where "Export to CSV" writes. The '@' is what keeps this outside the vault namespace:
+    // vault files live at config_dir()/<username> with no suffix, usernames may contain dots,
+    // and '@' cannot appear in a valid username -- so no account can ever share a path with an
+    // export. A plain "<username>.csv" name would be the vault file of an account literally
+    // named "alice.csv", and exporting from "alice" would overwrite that vault with plaintext.
+    std::string export_path(std::string const& username);
 } // namespace file::user_files
 
 // Remembers who logged in last so the login prompt can offer it as a default. Stores the

--- a/include/signup.h
+++ b/include/signup.h
@@ -2,10 +2,15 @@
 #define SIGNUP_H
 
 #include <string>
+#include <utility>
 
 namespace signup {
     auto promt() -> void;
-    auto valid_password() -> std::pair<bool, std::string>;
+
+    // Prompts for a password twice and requires both entries to match, retrying the whole pair
+    // up to 3 times on a mismatch. Shared by signup itself and by change_password, since both
+    // create a master password with no recovery path if it's mistyped.
+    auto confirmed_password() -> std::pair<bool, std::string>;
 } // namespace signup
 
 #endif // SIGNUP_H

--- a/include/str.h
+++ b/include/str.h
@@ -1,25 +1,14 @@
 #ifndef STR_H
 #define STR_H
 
-#ifdef _WIN32
-#include <ostream>
-#endif
-
 namespace str {
     using str_type = char const* const;
 
-#ifdef _WIN32
-    struct clear_screen {};
-    constexpr clear_screen clear_screen;
-
-    inline std::ostream& operator<<(std::ostream& os, struct clear_screen const&) {
-        system("cls");
-        return os;
-    }
-
-#else
+    // Shelling out to "cls" used to be the Windows path here (and drew antivirus complaints for
+    // it -- see the README). The ANSI escape works everywhere Redux runs now; Windows consoles
+    // just need ENABLE_VIRTUAL_TERMINAL_PROCESSING turned on first, which utils::enable_vt()
+    // does once at startup.
     str_type clear_screen = "\033[2J\033[1;1H";
-#endif // _WIN32
 
     str_type startup = R"(
               Welcome to Redux
@@ -96,6 +85,7 @@ namespace str {
     str_type username_prefix = "Enter your Username [";
     str_type username_suffix = "]: ";
     str_type password_again = "\nFor Security Reasons please enter your password again";
+    str_type password_mismatch = "Passwords do not match.\n\n";
 
     str_type choice = "Enter your choice: ";
     str_type empty = "Empty.\n";
@@ -108,6 +98,7 @@ namespace str {
     str_type ac_not_exists = "'s account doesn't exists.\n\n";
     str_type ac_pass_incorrect = "'s password is not correct.\n\n";
     str_type ac_already_exists = "'s account is already exists.\n\n";
+    str_type ac_in_use = "'s account is in use by another Redux instance.\n\n";
     str_type invalid_username =
         "A username must start with a letter or digit and may contain only letters, digits, "
         "'.', '-' and '_', up to 64 characters.\n\n";

--- a/include/utils.h
+++ b/include/utils.h
@@ -4,9 +4,16 @@
 #include <string>
 
 namespace utils {
-    // Reads a line of input without echoing it, restoring the terminal on every exit path --
-    // exceptions included. Throwing out of a password prompt used to skip the re-enabling call
-    // and leave the invoking Windows shell with echo switched off.
+    // Turns on ANSI escape sequence interpretation for stdout on Windows 10+ consoles, so
+    // str::clear_screen's escape codes clear the screen instead of printing literally. Purely
+    // cosmetic: any failure is ignored. Call once, at startup. A no-op on POSIX.
+    void enable_vt();
+
+    // Reads a line of input without echoing it. On Windows this restores the exact console mode
+    // that was active before the prompt on every exit path -- exceptions included -- rather than
+    // unconditionally re-enabling echo, and throws instead of proceeding if echo cannot be turned
+    // off on a real console, so a master password is never silently echoed to the screen. Piped
+    // or redirected stdin -- no console to mute -- is read through unchanged.
     std::string read_password(char const* prompt);
 } // namespace utils
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,32 @@
-file(GLOB app_src
-  "*.cpp")
-
 find_package(cryptopp CONFIG REQUIRED)
-add_executable(Redux ${app_src})
-target_include_directories(Redux PUBLIC ../include)
-target_compile_features(Redux PRIVATE cxx_std_17)
-target_link_libraries(Redux PRIVATE cryptopp::cryptopp)
+
+# The storage layer, split out from the app so tests/CMakeLists.txt can link it directly instead
+# of recompiling ../src files of its own -- one source list instead of two kept in sync by hand.
+add_library(redux_core STATIC
+  account.cpp
+  file.cpp
+  input.cpp
+)
+target_include_directories(redux_core PUBLIC ../include)
+target_compile_features(redux_core PUBLIC cxx_std_17)
+target_link_libraries(redux_core PUBLIC cryptopp::cryptopp)
+target_compile_options(redux_core PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>
+)
+
+add_executable(Redux
+  app.cpp
+  after_signin_services.cpp
+  feature.cpp
+  login.cpp
+  logout.cpp
+  signup.cpp
+  startup_services.cpp
+  utils.cpp
+)
+target_link_libraries(Redux PRIVATE redux_core)
+target_compile_options(Redux PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>
+)

--- a/src/account.cpp
+++ b/src/account.cpp
@@ -47,7 +47,19 @@ namespace account {
         }
     }
 
-    void create(user const& user) { file::vault::write(user.name, {}, user.password); }
+    already_exists::already_exists(std::string const& username)
+        : std::runtime_error{"account '" + username + "' already exists"} {}
+
+    void create(user const& user) {
+        // Rechecked here, under the caller's account lock, rather than trusting the pre-lock
+        // availability check: another process can register the same name between that check and
+        // this call (its lock is released when its session ends), and the second create must
+        // not replace the first user's vault.
+        if (exists(user.name)) {
+            throw already_exists{user.name};
+        }
+        file::vault::write(user.name, {}, user.password);
+    }
 
     void change_password(user const& user, std::string const& password) {
         auto const credentials = file::vault::read(user.name, user.password);

--- a/src/account.cpp
+++ b/src/account.cpp
@@ -3,9 +3,10 @@
 #include "file.h"
 #include "user.h"
 
+#include <cryptopp/filters.h>
+
 #include <algorithm>
 #include <cctype>
-#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -17,58 +18,39 @@ namespace account {
             return false;
         }
 
-        auto is_alnum = [](char c) {
-            return std::isalnum(static_cast<unsigned char>(c)) != 0;
-        };
+        auto is_alnum = [](char c) { return std::isalnum(static_cast<unsigned char>(c)) != 0; };
 
         // Requiring an alphanumeric first character rules out ".", "..", and Redux's own
-        // dot-prefixed state files in one go.
+        // dot-prefixed state files (lock files, staging files, ".last_user") in one go.
         if (!is_alnum(username.front())) {
             return false;
         }
 
-        return std::all_of(username.begin(), username.end(), [&](char c) {
-            return is_alnum(c) || c == '_' || c == '-' || c == '.';
-        });
+        return std::all_of(username.begin(), username.end(),
+                           [&](char c) { return is_alnum(c) || c == '_' || c == '-' || c == '.'; });
     }
 
-    bool exists(std::string const& username) {
-        return std::filesystem::exists(file::user_files::filePath(username));
-    }
+    bool exists(std::string const& username) { return file::vault::exists(username); }
 
     bool valid_password(user const& user) {
-        // The account file's plaintext is exactly the username, so decrypting it both
-        // authenticates (via the MAC) and sanity-checks. Nothing is written, so a failed attempt
-        // cannot leave the file in a state that locks the account out.
+        // A wrong password and a tampered vault are cryptographically indistinguishable, and
+        // HashVerificationFailed is the only exception that means one of those two things.
+        // Everything else -- an I/O failure, an unrecognized header, a vault whose recorded
+        // username does not match `user.name` -- is a different problem, and must not be
+        // reported as "wrong password": it propagates so the caller's handler can report what
+        // actually happened.
         try {
-            return file::crypt::read_decrypted(file::user_files::account(user.name),
-                                               user.password) == user.name;
-        } catch (...) {
+            file::vault::read(user.name, user.password);
+            return true;
+        } catch (CryptoPP::HashVerificationFilter::HashVerificationFailed const&) {
             return false;
         }
     }
 
-    void create(user const& user) {
-        namespace uf = file::user_files;
-
-        file::crypt::write_encrypted(uf::account(user.name), user.name, user.password);
-        file::crypt::write_encrypted(uf::data(user.name), "", user.password);
-    }
+    void create(user const& user) { file::vault::write(user.name, {}, user.password); }
 
     void change_password(user const& user, std::string const& password) {
-        namespace uf = file::user_files;
-
-        // Re-encrypt the vault itself under the new password. Nothing else does this: the files
-        // are always encrypted at rest, so there is no logout step left to pick it up.
-        //
-        // Going through file::credentials rather than crypt directly means an absent vault is
-        // handled here exactly as it is everywhere else, instead of throwing from a code path
-        // that menu item 7 reaches directly.
-        auto const credentials = file::credentials::read(uf::data(user.name), user.password);
-        file::credentials::write(uf::data(user.name), credentials, password);
-
-        // Each write is individually atomic, but the pair is not: an interruption between them
-        // leaves the vault on the new password and the account file on the old one.
-        file::crypt::write_encrypted(uf::account(user.name), user.name, password);
+        auto const credentials = file::vault::read(user.name, user.password);
+        file::vault::write(user.name, credentials, password);
     }
 } // namespace account

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,10 +1,13 @@
 #include "input.h"
 #include "startup_services.h"
+#include "utils.h"
 
 #include <exception>
 #include <iostream>
 
 int main() {
+    utils::enable_vt();
+
     try {
         startup_services::run();
     } catch (input::end_of_input const&) {

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -120,7 +120,7 @@ void feature::export_to_csv(user const& user_) {
         return;
     }
 
-    std::string const file_name = file::user_files::filePath(user_.name) + ".csv";
+    std::string const file_name = file::user_files::export_path(user_.name);
 
     file::users::writeToCSV(file_name, credentials);
 

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -6,6 +6,7 @@
 #include "user.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
 #include <vector>
 
@@ -14,13 +15,11 @@ enum confirm {
     no,
 };
 
-void feature::save() const {
-    file::credentials::write(file::user_files::data(username), credentials, password);
-}
+void feature::save() const { file::vault::write(username, credentials, password); }
 
 feature::feature(std::string username_, std::string password_)
     : username{std::move(username_)}, password{std::move(password_)},
-      credentials{file::credentials::read(file::user_files::data(username), password)} {}
+      credentials{file::vault::read(username, password)} {}
 
 static void print_credential(credential const& credential, int const number) {
     std::cout << "\n=========== " << number << " ===========\n"
@@ -52,7 +51,9 @@ void feature::add() {
 }
 
 static bool invalid_id(std::vector<credential> const& credentials, int const id) {
-    return id < 1 || id > credentials.size();
+    // id < 1 is checked (and short-circuits) before the cast, so the conversion to size_t below
+    // never turns a negative id into a huge unsigned value.
+    return id < 1 || static_cast<std::size_t>(id) > credentials.size();
 }
 
 void feature::edit() {
@@ -119,17 +120,12 @@ void feature::export_to_csv(user const& user_) {
         return;
     }
 
-    std::string file_name = file::user_files::filePath(user_.name) + ".csv";
+    std::string const file_name = file::user_files::filePath(user_.name) + ".csv";
 
-    for_each(cbegin(credentials), cend(credentials),
-             [n = 1, file_name](auto const& credential) mutable {
-                 // ToDO: add a check for the file existence
-                 // ToDO: Make unique file name(with username)
-                 file::users::writeToCSV(file_name, credential, n);
-                 ++n;
-             });
+    file::users::writeToCSV(file_name, credentials);
 
-    std::cout << "\nData Saved to "<<file_name<<"\n\n\n";
+    std::cout << "\nData Saved to " << file_name
+              << " (plaintext -- anyone with access to this file can read it)\n\n\n";
 
     input::enter();
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,76 +1,565 @@
 #include "file.h"
 #include "credential.h"
 
-#include <cryptopp/default.h>
+#include <cryptopp/aes.h>
 #include <cryptopp/filters.h>
+#include <cryptopp/gcm.h>
+#include <cryptopp/osrng.h>
+#include <cryptopp/scrypt.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <sstream>
 #include <stdexcept>
 #include <system_error>
+
 #ifdef _WIN32
+#include <windows.h>
+
+#include <aclapi.h>
 #include <userenv.h>
 #pragma comment(lib, "Userenv.lib")
+#pragma comment(lib, "Advapi32.lib")
+#else
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
 #endif
 
 namespace {
-    // Directory holding every file Redux owns. Empty when it cannot be determined, which makes
-    // the callers below fall back to bare relative names in the working directory.
-    std::filesystem::path config_dir() {
-#ifdef _WIN32
-        TCHAR szHomeDirBuf[MAX_PATH] = {0};
 
-        // We need a process with query permission set
-        HANDLE hToken = 0;
-        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken);
-        DWORD BufSize = MAX_PATH;
-        GetUserProfileDirectory(hToken, szHomeDirBuf, &BufSize);
-        // Close handle opened via OpenProcessToken
-        CloseHandle(hToken);
-        std::filesystem::path path = std::filesystem::path{szHomeDirBuf} / "Redux";
-#else
-        char const* home = std::getenv("HOME");
-        if (home == nullptr || std::string{home}.empty()) {
-            std::cerr << "HOME environment variable is not set\n";
-            return {};
+    // --- vault envelope layout -------------------------------------------------------------
+    //
+    // offset  0,  8 bytes: magic "REDUXVLT"
+    // offset  8,  1 byte : format version
+    // offset  9,  1 byte : kdf id (1 = scrypt)
+    // offset 10,  1 byte : log2(N)
+    // offset 11,  1 byte : r
+    // offset 12,  1 byte : p
+    // offset 13,  1 byte : salt length
+    // offset 14, 16 bytes: salt
+    // offset 30,  1 byte : nonce length
+    // offset 31, 12 bytes: nonce
+    // offset 43, rest    : AES-256-GCM ciphertext, followed by its 16-byte tag
+    //
+    // Every multibyte field here is a single byte, so the layout has no endianness to get wrong.
+    // The whole 43-byte header is authenticated as GCM additional data (AAD): tampering with the
+    // salt or the declared parameters is caught by the tag check on read, exactly like tampering
+    // with the ciphertext body would be.
+    constexpr std::size_t magic_size = 8;
+    constexpr std::size_t salt_size = 16;
+    constexpr std::size_t nonce_size = 12;
+    constexpr std::size_t tag_size = 16;
+    constexpr std::size_t key_size = 32; // AES-256
+    constexpr std::size_t salt_offset =
+        magic_size + 6; // magic + version + kdf + log2n + r + p + saltlen
+    constexpr std::size_t nonce_len_offset = salt_offset + salt_size;
+    constexpr std::size_t nonce_offset = nonce_len_offset + 1;
+    constexpr std::size_t header_size = nonce_offset + nonce_size;
+    static_assert(header_size == 43, "vault header layout must match the on-disk spec exactly");
+
+    constexpr std::uint8_t format_version = 0x01;
+    constexpr std::uint8_t kdf_scrypt = 0x01;
+    constexpr std::uint8_t default_log2n = 15;
+    constexpr std::uint8_t default_r = 8;
+    constexpr std::uint8_t default_p = 1;
+
+    // Anything below this is not meaningfully hard to brute-force; anything above it risks a
+    // multi-gigabyte allocation from a corrupted or hostile header before a single byte of
+    // ciphertext is even looked at. r and p need the same treatment: scrypt's memory use scales
+    // with N * r (and its work with p), key derivation runs before the GCM tag check, and all
+    // three come straight from header bytes -- a single corrupted r byte would otherwise force a
+    // pre-authentication allocation in the hundreds of megabytes.
+    constexpr std::uint8_t min_log2n = 10;
+    constexpr std::uint8_t max_log2n = 24;
+    constexpr std::uint8_t min_r = 1;
+    constexpr std::uint8_t max_r = 32;
+    constexpr std::uint8_t min_p = 1;
+    constexpr std::uint8_t max_p = 16;
+
+    constexpr char magic[magic_size] = {'R', 'E', 'D', 'U', 'X', 'V', 'L', 'T'};
+
+    // --- owner-only permissions -------------------------------------------------------------
+
+#ifdef _WIN32
+    // std::filesystem::permissions() on Windows only toggles the read-only attribute -- it
+    // cannot express "only this account may read this file" the way POSIX mode bits can. A
+    // protected DACL naming the current user's SID is the actual equivalent: PROTECTED stops the
+    // object from inheriting a more permissive ACL from its parent directory.
+    void set_owner_only(std::filesystem::path const& path) {
+        HANDLE token = nullptr;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+            throw std::runtime_error{"could not open the process token"};
         }
-        std::filesystem::path path = std::filesystem::path{home} / ".config" / "Redux";
+
+        DWORD needed = 0;
+        GetTokenInformation(token, TokenUser, nullptr, 0, &needed);
+        if (needed == 0) {
+            CloseHandle(token);
+            throw std::runtime_error{"could not size the process token user information"};
+        }
+
+        std::vector<BYTE> user_info(needed);
+        if (!GetTokenInformation(token, TokenUser, user_info.data(), needed, &needed)) {
+            CloseHandle(token);
+            throw std::runtime_error{"could not read the process token user information"};
+        }
+
+        PSID const user_sid = reinterpret_cast<TOKEN_USER*>(user_info.data())->User.Sid;
+        if (!IsValidSid(user_sid)) {
+            CloseHandle(token);
+            throw std::runtime_error{"process token did not contain a valid user SID"};
+        }
+
+        DWORD const acl_size = static_cast<DWORD>(sizeof(ACL) + sizeof(ACCESS_ALLOWED_ACE) +
+                                                  GetLengthSid(user_sid) - sizeof(DWORD));
+        std::vector<BYTE> acl_buffer(acl_size);
+        PACL const acl = reinterpret_cast<PACL>(acl_buffer.data());
+
+        if (!InitializeAcl(acl, acl_size, ACL_REVISION)) {
+            CloseHandle(token);
+            throw std::runtime_error{"could not initialize the ACL"};
+        }
+        if (!AddAccessAllowedAce(acl, ACL_REVISION, FILE_ALL_ACCESS, user_sid)) {
+            CloseHandle(token);
+            throw std::runtime_error{"could not add the owner ACE"};
+        }
+
+        std::wstring const wpath = path.wstring();
+        DWORD const result =
+            SetNamedSecurityInfoW(const_cast<LPWSTR>(wpath.c_str()), SE_FILE_OBJECT,
+                                  DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                                  nullptr, nullptr, acl, nullptr);
+
+        CloseHandle(token);
+
+        if (result != ERROR_SUCCESS) {
+            throw std::runtime_error{"could not restrict permissions on " + path.string()};
+        }
+    }
+#else
+    void set_owner_only(std::filesystem::path const& path) {
+        bool const is_dir = std::filesystem::is_directory(path);
+        std::error_code ec;
+        std::filesystem::permissions(
+            path,
+            is_dir ? std::filesystem::perms::owner_all
+                   : (std::filesystem::perms::owner_read | std::filesystem::perms::owner_write),
+            ec);
+        if (ec) {
+            throw std::runtime_error{"could not restrict permissions on " + path.string() + ": " +
+                                     ec.message()};
+        }
+    }
 #endif
-        std::filesystem::create_directories(path);
+
+    // --- config directory --------------------------------------------------------------------
+
+#ifdef _WIN32
+    std::filesystem::path windows_profile_dir() {
+        HANDLE token = nullptr;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+            throw std::runtime_error{"could not open the process token"};
+        }
+
+        DWORD size = MAX_PATH;
+        std::vector<wchar_t> buf(size);
+        BOOL ok = GetUserProfileDirectoryW(token, buf.data(), &size);
+        if (!ok && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+            buf.assign(size, L'\0');
+            ok = GetUserProfileDirectoryW(token, buf.data(), &size);
+        }
+
+        CloseHandle(token);
+
+        if (!ok) {
+            throw std::runtime_error{"could not determine the user profile directory"};
+        }
+
+        return std::filesystem::path{buf.data()};
+    }
+#endif
+
+    // Directory holding every file Redux owns. Never returns an empty or relative-to-nothing
+    // path: if it cannot be determined, it throws rather than falling back to a bare name in the
+    // working directory -- a machine with an unset HOME (a stripped container, a misconfigured
+    // service account) used to make Redux silently read and write secrets next to whatever the
+    // current directory happened to be.
+    std::filesystem::path config_dir() {
+        std::filesystem::path path;
+
+        // Checked on every platform, and first: this is also the hook the regression tests use
+        // to relocate storage into a sandbox, since overriding HOME doesn't work on Windows.
+        if (char const* dir = std::getenv("REDUX_CONFIG_DIR"); dir != nullptr && *dir != '\0') {
+            path = dir;
+        } else {
+#ifdef _WIN32
+            path = windows_profile_dir() / "Redux";
+#else
+            char const* home = std::getenv("HOME");
+            if (home == nullptr || *home == '\0') {
+                throw std::runtime_error{
+                    "HOME is not set; refusing to guess where the vault lives"};
+            }
+            path = std::filesystem::path{home} / ".config" / "Redux";
+#endif
+        }
+
+        std::error_code ec;
+        bool const created = std::filesystem::create_directories(path, ec);
+        if (ec) {
+            throw std::runtime_error{"could not create " + path.string() + ": " + ec.message()};
+        }
+
+        // Restricted once, at creation -- not on every call. Re-asserting owner-only permissions
+        // on every lookup would silently undo any tightening an operator applied afterwards (or,
+        // more mundanely, a directory made temporarily unwritable to simulate a full disk).
+        if (created) {
+            set_owner_only(path);
+        }
         return path;
     }
+
+    // --- atomic, owner-only writes -----------------------------------------------------------
+
+#ifdef _WIN32
+    unsigned long current_pid() { return GetCurrentProcessId(); }
+#else
+    unsigned long current_pid() { return static_cast<unsigned long>(getpid()); }
+#endif
+
+    // Dot-prefixed so it cannot collide with a real account: a valid username must begin with an
+    // alphanumeric (account::valid_username), so no account is ever named like a staging file.
+    // The pid and 8 random hex characters mean two concurrent writes -- from two Redux instances,
+    // or two rapid writes from the same process -- can never land on the same staging name and
+    // clobber each other.
+    std::string staging_name(std::string const& filename) {
+        CryptoPP::AutoSeededRandomPool rng;
+        CryptoPP::byte random_bytes[4];
+        rng.GenerateBlock(random_bytes, sizeof(random_bytes));
+
+        std::ostringstream suffix;
+        suffix << std::hex << std::setfill('0');
+        for (auto b : random_bytes) {
+            suffix << std::setw(2) << static_cast<unsigned>(b);
+        }
+
+        return "." + filename + "." + std::to_string(current_pid()) + "." + suffix.str() + ".tmp";
+    }
+
+    // Writes `bytes` to a sibling staging file and renames it over `target`. Opening the target
+    // directly with trunc would destroy the old contents before the new bytes were known to be
+    // good, so a failing write would leave a truncated, unreadable file -- this makes the
+    // failure visible instead, with the previous file untouched.
+    void write_file_atomic(std::filesystem::path const& target, std::string const& bytes) {
+        std::filesystem::path const staging =
+            target.parent_path() / staging_name(target.filename().string());
+
+        {
+            // Binary: the payload can be ciphertext, and a text-mode stream would translate LF
+            // to CRLF inside it on Windows and corrupt it.
+            std::ofstream out{staging, std::ios::binary | std::ios::trunc};
+            out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+
+            // Close here rather than letting the destructor do it. Some filesystems only report
+            // a deferred write error when the file is closed, and a destructor has no way to
+            // report it -- the staging file would then be renamed over a good file while holding
+            // incomplete bytes. Checking after the close is what makes the rename safe.
+            out.close();
+
+            if (!out) {
+                std::error_code ec;
+                std::filesystem::remove(staging, ec);
+                throw std::runtime_error{"could not write " + target.string()};
+            }
+        }
+
+#ifndef _WIN32
+        // The rename below publishes whatever has reached the disk, not whatever was written: a
+        // crash shortly after could otherwise publish an empty or partial file over a good one.
+        // Windows durability is left to the OS here by design.
+        {
+            int const fd = open(staging.c_str(), O_RDONLY);
+            bool const synced = fd >= 0 && fsync(fd) == 0;
+            if (fd >= 0) {
+                close(fd);
+            }
+            if (!synced) {
+                std::error_code ec;
+                std::filesystem::remove(staging, ec);
+                throw std::runtime_error{"could not flush " + target.string() + " to disk"};
+            }
+        }
+#endif
+
+        try {
+            // Owner-only before it is published, so the file is never briefly readable by anyone
+            // else between the write and the rename.
+            set_owner_only(staging);
+        } catch (...) {
+            std::error_code ec;
+            std::filesystem::remove(staging, ec);
+            throw;
+        }
+
+        std::error_code ec;
+        std::filesystem::rename(staging, target, ec);
+        if (ec) {
+            std::error_code cleanup_ec;
+            std::filesystem::remove(staging, cleanup_ec);
+            throw std::runtime_error{"could not publish " + target.string() + ": " + ec.message()};
+        }
+
+#ifndef _WIN32
+        // Make the rename itself durable across a crash. Best-effort: the file is already
+        // published and readable, so a directory fsync failure is not worth failing the write
+        // over.
+        if (int const dir_fd = open(target.parent_path().c_str(), O_RDONLY); dir_fd >= 0) {
+            fsync(dir_fd);
+            close(dir_fd);
+        }
+#endif
+    }
+
+    // --- key derivation and the header ---------------------------------------------------------
+
+    CryptoPP::SecByteBlock derive_key(std::string const& password, CryptoPP::byte const* salt,
+                                      std::uint8_t log2n, std::uint8_t r, std::uint8_t p) {
+        CryptoPP::SecByteBlock key(key_size);
+        CryptoPP::Scrypt{}.DeriveKey(
+            key.data(), key.size(), reinterpret_cast<CryptoPP::byte const*>(password.data()),
+            password.size(), salt, salt_size, static_cast<CryptoPP::word64>(1) << log2n, r, p);
+        return key;
+    }
+
+    std::string build_header(CryptoPP::byte const* salt, CryptoPP::byte const* nonce) {
+        std::string header;
+        header.reserve(header_size);
+        header.append(magic, magic_size);
+        header.push_back(static_cast<char>(format_version));
+        header.push_back(static_cast<char>(kdf_scrypt));
+        header.push_back(static_cast<char>(default_log2n));
+        header.push_back(static_cast<char>(default_r));
+        header.push_back(static_cast<char>(default_p));
+        header.push_back(static_cast<char>(salt_size));
+        header.append(reinterpret_cast<char const*>(salt), salt_size);
+        header.push_back(static_cast<char>(nonce_size));
+        header.append(reinterpret_cast<char const*>(nonce), nonce_size);
+        return header;
+    }
+
 } // namespace
 
-namespace file::user_files {
+namespace file::vault {
 
-    std::string filePath(std::string const& username) {
-        return (config_dir() / username).string();
+    std::filesystem::path path(std::string const& username) { return config_dir() / username; }
+
+    bool exists(std::string const& username) { return std::filesystem::exists(path(username)); }
+
+    void write(std::string const& username, std::vector<credential> const& credentials,
+               std::string const& password) {
+        using namespace CryptoPP;
+
+        // The plaintext identifies the account it belongs to. On read, the first line must match
+        // the username being read under -- catching a vault renamed onto, or substituted for,
+        // another account's file, which a MAC alone would not: the ciphertext would still be
+        // internally valid, just for the wrong account.
+        std::string plaintext = username + '\n';
+        for (auto const& cred : credentials) {
+            std::ostringstream line;
+            line << cred;
+            plaintext += line.str();
+        }
+
+        AutoSeededRandomPool rng;
+        byte salt[salt_size];
+        rng.GenerateBlock(salt, salt_size);
+        byte nonce[nonce_size];
+        rng.GenerateBlock(nonce, nonce_size);
+
+        auto const key = derive_key(password, salt, default_log2n, default_r, default_p);
+        std::string const header = build_header(salt, nonce);
+
+        GCM<AES>::Encryption enc;
+        enc.SetKeyWithIV(key.data(), key.size(), nonce, nonce_size);
+
+        std::string ciphertext;
+        AuthenticatedEncryptionFilter ef{enc, new StringSink{ciphertext}, false, tag_size};
+        ef.ChannelPut(AAD_CHANNEL, reinterpret_cast<byte const*>(header.data()), header.size());
+        ef.ChannelMessageEnd(AAD_CHANNEL);
+        ef.ChannelPut(DEFAULT_CHANNEL, reinterpret_cast<byte const*>(plaintext.data()),
+                      plaintext.size());
+        ef.ChannelMessageEnd(DEFAULT_CHANNEL);
+
+        write_file_atomic(path(username), header + ciphertext);
     }
-    // '@' cannot appear in a valid username, which is what keeps this suffix from colliding with
-    // another account: with the old "_data" suffix, registering "alice_data" silently took over
-    // the vault belonging to "alice".
-    std::string data(std::string const& username) { return filePath(username) + "@vault"; }
-    std::string account(std::string const& username) { return filePath(username); }
+
+    std::vector<credential> read(std::string const& username, std::string const& password) {
+        using namespace CryptoPP;
+
+        auto const p = path(username);
+        if (!std::filesystem::exists(p)) {
+            throw std::runtime_error{"no vault for " + username};
+        }
+
+        std::ifstream in{p, std::ios::binary};
+        if (!in) {
+            throw std::runtime_error{"could not open the vault for " + username};
+        }
+        std::string const bytes{std::istreambuf_iterator<char>{in},
+                                std::istreambuf_iterator<char>{}};
+
+        if (bytes.size() < header_size) {
+            throw std::runtime_error{"not a Redux vault: file is smaller than the header"};
+        }
+        if (bytes.compare(0, magic_size, magic, magic_size) != 0) {
+            throw std::runtime_error{"not a Redux vault: bad magic"};
+        }
+
+        auto const version = static_cast<std::uint8_t>(bytes[8]);
+        auto const kdf_id = static_cast<std::uint8_t>(bytes[9]);
+        auto const log2n = static_cast<std::uint8_t>(bytes[10]);
+        auto const r = static_cast<std::uint8_t>(bytes[11]);
+        auto const p_param = static_cast<std::uint8_t>(bytes[12]);
+        auto const salt_len = static_cast<std::uint8_t>(bytes[13]);
+        auto const nonce_len = static_cast<std::uint8_t>(bytes[nonce_len_offset]);
+
+        if (version != format_version || kdf_id != kdf_scrypt) {
+            throw std::runtime_error{"unsupported Redux vault format: unknown version or KDF"};
+        }
+        // A sanity range on the cost parameters, not the exact values written today: read must
+        // still accept a vault written by an earlier build with different (but still sane)
+        // scrypt parameters, which is why write always uses the current defaults but read honors
+        // whatever the header declares. r and p are bounded for the same reason as log2n: they
+        // reach scrypt before the tag check authenticates the header, so an out-of-range value
+        // turns one corrupted byte into a huge pre-authentication allocation.
+        if (log2n < min_log2n || log2n > max_log2n) {
+            throw std::runtime_error{"unsupported Redux vault format: unreasonable scrypt cost"};
+        }
+        if (r < min_r || r > max_r || p_param < min_p || p_param > max_p) {
+            throw std::runtime_error{
+                "unsupported Redux vault format: unreasonable scrypt parameters"};
+        }
+        if (salt_len != salt_size || nonce_len != nonce_size) {
+            throw std::runtime_error{
+                "unsupported Redux vault format: unexpected salt or nonce length"};
+        }
+
+        auto const* salt = reinterpret_cast<byte const*>(bytes.data() + salt_offset);
+        auto const* nonce = reinterpret_cast<byte const*>(bytes.data() + nonce_offset);
+
+        auto const key = derive_key(password, salt, log2n, r, p_param);
+
+        GCM<AES>::Decryption dec;
+        dec.SetKeyWithIV(key.data(), key.size(), nonce, nonce_size);
+
+        std::string plaintext;
+        AuthenticatedDecryptionFilter df{dec, new StringSink{plaintext},
+                                         AuthenticatedDecryptionFilter::MAC_AT_END |
+                                             AuthenticatedDecryptionFilter::THROW_EXCEPTION,
+                                         tag_size};
+
+        df.ChannelPut(AAD_CHANNEL, reinterpret_cast<byte const*>(bytes.data()), header_size);
+        df.ChannelMessageEnd(AAD_CHANNEL);
+        df.ChannelPut(DEFAULT_CHANNEL, reinterpret_cast<byte const*>(bytes.data() + header_size),
+                      bytes.size() - header_size);
+        df.ChannelMessageEnd(DEFAULT_CHANNEL);
+        // A wrong password or any tampering with the header or ciphertext throws
+        // CryptoPP::HashVerificationFilter::HashVerificationFailed here -- the two are
+        // indistinguishable, which is exactly what account::valid_password relies on.
+
+        std::istringstream plaintext_stream{plaintext};
+        std::string stored_username;
+        std::getline(plaintext_stream, stored_username);
+        if (stored_username != username) {
+            throw std::runtime_error{"vault username mismatch: expected " + username};
+        }
+
+        std::vector<credential> result;
+        credential cred;
+        while (plaintext_stream >> cred) {
+            result.push_back(cred);
+        }
+        return result;
+    }
+
+} // namespace file::vault
+
+namespace file::users {
+
+    namespace {
+        // OWASP CSV-injection neutralization: some spreadsheet programs interpret a cell as a
+        // formula when it opens with one of these characters, which turns an exported credential
+        // into a code-execution vector the moment someone double-clicks the file. Prefixing a
+        // single quote inside the quotes defuses that without changing what the field displays.
+        bool starts_with_formula_char(std::string const& field) {
+            if (field.empty()) {
+                return false;
+            }
+            switch (field.front()) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        // Every field is quoted unconditionally -- it never needs to be inspected further to
+        // decide, and it is what keeps a field safe even if a future caller adds one that can
+        // contain a comma or a quote itself.
+        std::string quote_field(std::string const& field) {
+            std::string quoted = "\"";
+            if (starts_with_formula_char(field)) {
+                quoted += '\'';
+            }
+            for (char c : field) {
+                if (c == '"') {
+                    quoted += "\"\"";
+                } else {
+                    quoted += c;
+                }
+            }
+            quoted += '"';
+            return quoted;
+        }
+    } // namespace
+
+    void writeToCSV(std::string const& filename, std::vector<credential> const& credentials) {
+        std::ostringstream out;
+        out << "ID,Company Name,Username,Password\n";
+
+        int id = 1;
+        for (auto const& cred : credentials) {
+            out << id << ',' << quote_field(cred.company_name) << ',' << quote_field(cred.username)
+                << ',' << quote_field(cred.password) << "\n";
+            ++id;
+        }
+
+        write_file_atomic(filename, out.str());
+    }
+
+} // namespace file::users
+
+namespace file::user_files {
+    std::string filePath(std::string const& username) { return (config_dir() / username).string(); }
 } // namespace file::user_files
 
 namespace file::last_user {
 
     void save(std::string const& username) {
         try {
-            auto const dir = config_dir();
-            if (dir.empty()) {
-                return;
-            }
-            std::filesystem::permissions(dir, std::filesystem::perms::owner_all);
-
-            auto const path = dir / ".last_user";
-            std::ofstream{path} << username;
-            std::filesystem::permissions(path, std::filesystem::perms::owner_read |
-                                                   std::filesystem::perms::owner_write);
+            auto const path = config_dir() / ".last_user";
+            write_file_atomic(path, username);
         } catch (...) {
             // Remembering the username is a convenience. Never let it break signing in.
         }
@@ -94,107 +583,91 @@ namespace file::last_user {
     }
 } // namespace file::last_user
 
-namespace file::users {
+namespace file {
 
-    void writeToCSV(std::string filename, credential const& user_credentials, int const number) {
-        if (number == 1) {
-            std::ofstream{filename, std::ios::out} << "ID,Company Name,Username,Password\n";
-        }
-        std::ofstream{filename, std::ios::app} << number << "," << user_credentials.company_name
-                                               << "," << user_credentials.username << ","
-                                               << user_credentials.password << "\n";
-    }
-} // namespace file::users
+    account_busy::account_busy(std::string const& username)
+        : std::runtime_error{"account '" + username + "' is locked by another Redux instance"} {}
 
-namespace file::credentials {
-    void write(std::string const& filename, std::vector<credential> const& credentials,
-               std::string const& password) {
-        std::ostringstream plaintext;
+    // The descriptor is closed by impl's own destructor, not by ~account_lock: move-assignment
+    // replaces impl_ wholesale, and a close living in ~account_lock would never run for the impl
+    // being replaced -- leaking the descriptor and holding the lock for the rest of the process.
+    // Closing releases only the lock; the lock file itself is left in place, so acquiring it
+    // again is just opening the same, already-existing file.
+    struct account_lock::impl {
+#ifdef _WIN32
+        HANDLE handle = INVALID_HANDLE_VALUE;
 
-        for (auto const& cre : credentials) {
-            plaintext << cre;
-        }
-
-        file::crypt::write_encrypted(filename, plaintext.str(), password);
-    }
-
-    std::vector<credential> read(std::string const& filename, std::string const& password) {
-        std::vector<credential> result;
-
-        if (!std::filesystem::exists(filename)) {
-            return result;
-        }
-
-        std::istringstream plaintext{file::crypt::read_decrypted(filename, password)};
-
-        credential credential;
-        while (plaintext >> credential) {
-            result.push_back(credential);
-        }
-
-        return result;
-    }
-} // namespace file::credentials
-
-namespace file::crypt {
-
-    void write_encrypted(std::string const& filename, std::string const& plaintext,
-                         std::string const& password) {
-        using namespace CryptoPP;
-
-        std::string ciphertext;
-        StringSource{plaintext, true,
-                     new DefaultEncryptorWithMAC{reinterpret_cast<byte const*>(password.data()),
-                                                 password.size(), new StringSink{ciphertext}}};
-
-        // Write to a sibling temp file and rename it over the target. Opening the target with
-        // trunc would destroy the old contents before the new bytes were known to be on disk, so
-        // a failing write would leave a 0-byte vault -- unreadable, and unrecoverable.
-        // The staging name is dot-prefixed so it cannot collide with a real user's file: a valid
-        // username must begin with an alphanumeric, so no account file is ever named ".<x>.new".
-        // Naming it "<filename>.new" would mean saving user "alice" clobbers user "alice.new".
-        std::filesystem::path const target{filename};
-        std::filesystem::path const staging =
-            target.parent_path() / ('.' + target.filename().string() + ".new");
-
-        {
-            // Binary: the payload is ciphertext, and a text-mode stream would translate LF to
-            // CRLF inside it on Windows and corrupt it.
-            std::ofstream out{staging, std::ios::binary | std::ios::trunc};
-            out.write(ciphertext.data(), static_cast<std::streamsize>(ciphertext.size()));
-
-            // Close here rather than letting the destructor do it. Some filesystems only report a
-            // deferred write error when the file is closed, and a destructor has no way to report
-            // it -- the staging file would then be renamed over a good vault while holding
-            // incomplete ciphertext. Checking after the close is what makes the rename safe.
-            out.close();
-
-            if (!out) {
-                std::error_code ec;
-                std::filesystem::remove(staging, ec);
-                throw std::runtime_error{"could not write " + target.string()};
+        ~impl() {
+            if (handle != INVALID_HANDLE_VALUE) {
+                CloseHandle(handle);
             }
         }
+#else
+        int fd = -1;
 
-        // Owner-only before it is published, so the file is never briefly world-readable.
-        std::filesystem::permissions(staging, std::filesystem::perms::owner_read |
-                                                  std::filesystem::perms::owner_write);
+        ~impl() {
+            if (fd >= 0) {
+                close(fd);
+            }
+        }
+#endif
+    };
 
-        std::filesystem::rename(staging, target);
+#ifdef _WIN32
+    account_lock::account_lock(std::string const& username) : impl_{std::make_unique<impl>()} {
+        auto const lock_path = config_dir() / ("." + username + ".lock");
+
+        // The share mode must not be 0: a second instance has to be able to open the file at all
+        // so that LockFileEx is what arbitrates exclusivity -- with no sharing, the second open
+        // itself fails with ERROR_SHARING_VIOLATION and the account_busy path below is
+        // unreachable.
+        impl_->handle = CreateFileW(lock_path.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
+                                    FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+                                    FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (impl_->handle == INVALID_HANDLE_VALUE) {
+            // Something else holding the file un-shared still means the account is in use, not
+            // that Redux is broken.
+            if (GetLastError() == ERROR_SHARING_VIOLATION) {
+                throw account_busy{username};
+            }
+            throw std::runtime_error{"could not open the lock file for " + username};
+        }
+
+        OVERLAPPED overlapped{};
+        if (!LockFileEx(impl_->handle, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0,
+                        MAXDWORD, MAXDWORD, &overlapped)) {
+            DWORD const err = GetLastError();
+            CloseHandle(impl_->handle);
+            impl_->handle = INVALID_HANDLE_VALUE;
+            if (err == ERROR_LOCK_VIOLATION) {
+                throw account_busy{username};
+            }
+            throw std::runtime_error{"could not lock " + lock_path.string()};
+        }
     }
+#else
+    account_lock::account_lock(std::string const& username) : impl_{std::make_unique<impl>()} {
+        auto const lock_path = config_dir() / ("." + username + ".lock");
 
-    std::string read_decrypted(std::string const& filename, std::string const& password) {
-        using namespace CryptoPP;
+        impl_->fd = open(lock_path.c_str(), O_CREAT | O_RDWR, 0600);
+        if (impl_->fd < 0) {
+            throw std::runtime_error{"could not open the lock file for " + username};
+        }
 
-        std::ifstream in{filename, std::ios::binary};
-        std::string const ciphertext{std::istreambuf_iterator<char>{in},
-                                     std::istreambuf_iterator<char>{}};
-
-        std::string plaintext;
-        StringSource{ciphertext, true,
-                     new DefaultDecryptorWithMAC{reinterpret_cast<byte const*>(password.data()),
-                                                 password.size(), new StringSink{plaintext}}};
-
-        return plaintext;
+        if (flock(impl_->fd, LOCK_EX | LOCK_NB) != 0) {
+            int const err = errno;
+            close(impl_->fd);
+            impl_->fd = -1;
+            if (err == EWOULDBLOCK) {
+                throw account_busy{username};
+            }
+            throw std::runtime_error{"could not lock " + lock_path.string()};
+        }
     }
-} // namespace file::crypt
+#endif
+
+    account_lock::~account_lock() = default;
+    account_lock::account_lock(account_lock&&) noexcept = default;
+    account_lock& account_lock::operator=(account_lock&&) noexcept = default;
+
+} // namespace file

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -82,6 +82,12 @@ namespace {
     constexpr std::uint8_t min_p = 1;
     constexpr std::uint8_t max_p = 16;
 
+    // The per-parameter ranges alone still admit combinations whose scrypt working set
+    // (128 * N * r bytes) reaches 64 GiB -- enough for one corrupted header to OOM the process
+    // before the GCM tag can reject it. The product is what has to be bounded; this ceiling sits
+    // comfortably above anything write() produces (32 MiB today) while staying survivable.
+    constexpr std::uint64_t max_scrypt_memory = 256ull * 1024 * 1024;
+
     constexpr char magic[magic_size] = {'R', 'E', 'D', 'U', 'X', 'V', 'L', 'T'};
 
     // --- owner-only permissions -------------------------------------------------------------
@@ -444,6 +450,10 @@ namespace file::vault {
         if (r < min_r || r > max_r || p_param < min_p || p_param > max_p) {
             throw std::runtime_error{
                 "unsupported Redux vault format: unreasonable scrypt parameters"};
+        }
+        if ((128ull << log2n) * r > max_scrypt_memory) {
+            throw std::runtime_error{
+                "unsupported Redux vault format: unreasonable scrypt memory cost"};
         }
         if (salt_len != salt_size || nonce_len != nonce_size) {
             throw std::runtime_error{

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -88,6 +88,12 @@ namespace {
     // comfortably above anything write() produces (32 MiB today) while staying survivable.
     constexpr std::uint64_t max_scrypt_memory = 256ull * 1024 * 1024;
 
+    // Memory is not the only pre-authentication cost: running time scales with N * r * p, and a
+    // header can stay under the memory ceiling while declaring work far beyond it (log2(N)=21,
+    // r=1, p=16 fits in 256 MiB but stalls login for tens of seconds). Sixteen times today's
+    // write-side work (2^15 * 8 * 1) is the generous end of sane.
+    constexpr std::uint64_t max_scrypt_work = 1ull << 22;
+
     constexpr char magic[magic_size] = {'R', 'E', 'D', 'U', 'X', 'V', 'L', 'T'};
 
     // --- owner-only permissions -------------------------------------------------------------
@@ -455,6 +461,10 @@ namespace file::vault {
             throw std::runtime_error{
                 "unsupported Redux vault format: unreasonable scrypt memory cost"};
         }
+        if ((std::uint64_t{1} << log2n) * r * p_param > max_scrypt_work) {
+            throw std::runtime_error{
+                "unsupported Redux vault format: unreasonable scrypt work cost"};
+        }
         if (salt_len != salt_size || nonce_len != nonce_size) {
             throw std::runtime_error{
                 "unsupported Redux vault format: unexpected salt or nonce length"};
@@ -561,7 +571,11 @@ namespace file::users {
 } // namespace file::users
 
 namespace file::user_files {
-    std::string filePath(std::string const& username) { return (config_dir() / username).string(); }
+    // The '@' cannot appear in a valid username, which is what makes this path provably
+    // distinct from every vault file -- see the header comment.
+    std::string export_path(std::string const& username) {
+        return (config_dir() / (username + "@export.csv")).string();
+    }
 } // namespace file::user_files
 
 namespace file::last_user {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -371,7 +372,18 @@ namespace file::vault {
 
     std::filesystem::path path(std::string const& username) { return config_dir() / username; }
 
-    bool exists(std::string const& username) { return std::filesystem::exists(path(username)); }
+    // Existence means "a current-format vault", not just "a file with this name". The old
+    // format's account verifier lived at this exact path, and there is deliberately no
+    // migration -- if its mere presence counted, it would squat the username forever: signup
+    // would refuse the name and login could never read it. A file without the magic is treated
+    // as absent, so signing up reclaims the name (and overwrites the stale file).
+    bool exists(std::string const& username) {
+        std::ifstream in{path(username), std::ios::binary};
+        char head[magic_size] = {};
+        in.read(head, magic_size);
+        return in.gcount() == static_cast<std::streamsize>(magic_size) &&
+               std::memcmp(head, magic, magic_size) == 0;
+    }
 
     void write(std::string const& username, std::vector<credential> const& credentials,
                std::string const& password) {

--- a/src/login.cpp
+++ b/src/login.cpp
@@ -8,6 +8,7 @@
 #include "utils.h"
 
 #include <iostream>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -15,6 +16,20 @@ namespace login {
     static void exceeds_attempt() {
         std::cout << str::clear_screen;
         input::enter(str::exceeds_attempt);
+    }
+
+    // Acquired non-blocking right after the username is validated, and held by the caller for
+    // the whole session: a second Redux instance signed into the same account could otherwise
+    // race a read-modify-write cycle (most visibly change_password) against this one.
+    static bool acquire_lock(std::string const& username, std::optional<file::account_lock>& lock) {
+        try {
+            lock.emplace(username);
+            return true;
+        } catch (file::account_busy const&) {
+            std::cout << username << str::ac_in_use;
+            input::enter();
+            return false;
+        }
     }
 
     static auto valid_username() {
@@ -70,6 +85,11 @@ namespace login {
         if (auto [valid, username] = valid_username(); valid) {
             user.name = username;
         } else {
+            return;
+        }
+
+        std::optional<file::account_lock> lock;
+        if (!acquire_lock(user.name, lock)) {
             return;
         }
 

--- a/src/logout.cpp
+++ b/src/logout.cpp
@@ -11,22 +11,11 @@
 
 bool change_password(user const& user_) {
     std::cout << "\n";
-    auto [valid, new_password] = signup::valid_password();
+    auto [valid, new_password] = signup::confirmed_password();
     if (!valid) {
         return false;
     }
-    std::cout << str::password_again << "\n";
-    auto [valid_again, new_password_again] = signup::valid_password();
-    if (!valid_again) {
-        return false;
-    }
 
-    if (new_password != new_password_again) {
-        std::cout << str::clear_screen;
-        std::cout << "Password do not match\n";
-        input::enter();
-        return false;
-    }
     account::change_password(user_, new_password);
 
     std::cout << str::clear_screen << "Password Changed\n\n";

--- a/src/signup.cpp
+++ b/src/signup.cpp
@@ -19,8 +19,9 @@ namespace signup {
     }
 
     // Acquired non-blocking right after the username is validated, and held by the caller for
-    // the whole session. This also protects signup itself: two processes racing to register the
-    // same username can no longer both reach account::create for it.
+    // the whole session. The lock alone cannot serialize two signups for the same name -- the
+    // winner's lock is released when its session ends, and the loser then acquires it freely.
+    // It is account::create's under-lock existence recheck that closes that race.
     static bool acquire_lock(std::string const& username, std::optional<file::account_lock>& lock) {
         try {
             lock.emplace(username);
@@ -119,7 +120,15 @@ namespace signup {
         if (auto [valid, password] = confirmed_password(); valid) {
             user.password = password;
 
-            account::create(user);
+            try {
+                account::create(user);
+            } catch (account::already_exists const&) {
+                // Another instance registered this name while we were prompting. Its vault must
+                // not be replaced -- the name is simply taken now.
+                std::cout << user.name << str::ac_already_exists;
+                input::enter();
+                return;
+            }
 
             file::last_user::save(user.name);
 

--- a/src/signup.cpp
+++ b/src/signup.cpp
@@ -8,6 +8,7 @@
 #include "utils.h"
 
 #include <iostream>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -15,6 +16,20 @@ namespace signup {
     static void exceeds_attempt() {
         std::cout << str::clear_screen;
         input::enter(str::exceeds_attempt);
+    }
+
+    // Acquired non-blocking right after the username is validated, and held by the caller for
+    // the whole session. This also protects signup itself: two processes racing to register the
+    // same username can no longer both reach account::create for it.
+    static bool acquire_lock(std::string const& username, std::optional<file::account_lock>& lock) {
+        try {
+            lock.emplace(username);
+            return true;
+        } catch (file::account_busy const&) {
+            std::cout << username << str::ac_in_use;
+            input::enter();
+            return false;
+        }
     }
 
     static auto valid_username() {
@@ -39,7 +54,7 @@ namespace signup {
         return std::make_pair(true, username);
     }
 
-    std::pair<bool, std::string> valid_password() {
+    static std::pair<bool, std::string> valid_password() {
         std::string password = utils::read_password(str::password);
 
         int input_attempt = 0;
@@ -57,6 +72,36 @@ namespace signup {
         return {true, password};
     }
 
+    // A password typed once and mistyped creates an account nobody can get back into -- the new
+    // vault format has no recovery path. Requiring the same password twice, with its own
+    // exceeds-attempt budget on a mismatch, is the only guard against that.
+    std::pair<bool, std::string> confirmed_password() {
+        int mismatch_attempt = 0;
+        while (true) {
+            auto [valid, password] = valid_password();
+            if (!valid) {
+                return {false, {}};
+            }
+
+            std::cout << str::password_again << "\n";
+            auto [valid_again, password_again] = valid_password();
+            if (!valid_again) {
+                return {false, {}};
+            }
+
+            if (password == password_again) {
+                return {true, password};
+            }
+
+            if (++mismatch_attempt == 3) {
+                exceeds_attempt();
+                return {false, {}};
+            }
+
+            std::cout << str::password_mismatch;
+        }
+    }
+
     void promt() {
         user user;
 
@@ -66,7 +111,12 @@ namespace signup {
             return;
         }
 
-        if (auto [valid, password] = valid_password(); valid) {
+        std::optional<file::account_lock> lock;
+        if (!acquire_lock(user.name, lock)) {
+            return;
+        }
+
+        if (auto [valid, password] = confirmed_password(); valid) {
             user.password = password;
 
             account::create(user);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,37 +12,65 @@
 
 namespace {
 #ifdef _WIN32
-    void set_console_echo(bool const enabled) {
-        HANDLE const stdin_handle = GetStdHandle(STD_INPUT_HANDLE);
-
-        DWORD mode = 0;
-        if (GetConsoleMode(stdin_handle, &mode) == 0) {
-            return;
-        }
-
-        if (enabled) {
-            mode |= ENABLE_ECHO_INPUT;
-        } else {
-            mode &= ~ENABLE_ECHO_INPUT;
-        }
-
-        SetConsoleMode(stdin_handle, mode);
-    }
-
-    // The console is shared with the shell that launched Redux, so echo has to come back however
-    // the scope is left.
+    // The console is shared with the shell that launched Redux, so what comes back on scope exit
+    // has to be the exact mode that was active before -- not just echo forced back on, which
+    // would clobber any other mode bits (line input, mouse/window input, VT processing) the shell
+    // had set and Redux never touched.
+    //
+    // If GetConsoleMode fails, stdin isn't a console at all -- a pipe or redirected file -- and
+    // there is nothing to mute or restore, so the guard stays inactive and reads proceed as-is.
+    // If it IS a console and echo cannot be turned off, silently continuing would echo a master
+    // password to the screen, so that case fails closed instead.
     class echo_guard {
     public:
-        echo_guard() { set_console_echo(false); }
-        ~echo_guard() { set_console_echo(true); }
+        echo_guard() {
+            handle_ = GetStdHandle(STD_INPUT_HANDLE);
+            if (GetConsoleMode(handle_, &original_mode_) == 0) {
+                return;
+            }
+
+            active_ = true;
+
+            if (SetConsoleMode(handle_, original_mode_ & ~ENABLE_ECHO_INPUT) == 0) {
+                throw std::runtime_error{"could not disable console echo"};
+            }
+        }
+
+        ~echo_guard() {
+            if (active_) {
+                SetConsoleMode(handle_, original_mode_);
+            }
+        }
 
         echo_guard(echo_guard const&) = delete;
         echo_guard& operator=(echo_guard const&) = delete;
+
+    private:
+        HANDLE handle_ = nullptr;
+        DWORD original_mode_ = 0;
+        bool active_ = false;
     };
 #endif
 } // namespace
 
 namespace utils {
+    void enable_vt() {
+#ifdef _WIN32
+        // Windows 10+ consoles don't interpret ANSI escape sequences until asked to -- without
+        // this, str::clear_screen prints its escape codes literally instead of clearing anything.
+        // Cosmetic only: unlike echo, nothing sensitive leaks if this silently no-ops, so any
+        // failure (non-console stdout, an older console) is simply ignored.
+        HANDLE const stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+
+        DWORD mode = 0;
+        if (GetConsoleMode(stdout_handle, &mode) == 0) {
+            return;
+        }
+
+        SetConsoleMode(stdout_handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+#endif
+    }
+
     std::string read_password(char const* const prompt) {
 #ifdef _WIN32
         echo_guard const guard;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,19 +1,19 @@
-find_package(cryptopp CONFIG REQUIRED)
-
-# The storage layer only, without app.cpp -- the test provides its own main().
+# The storage layer only, without app.cpp -- the test provides its own main(). Links redux_core
+# (defined in src/CMakeLists.txt) rather than recompiling ../src files of its own, so there is one
+# source list for the storage layer, not two kept in sync by hand.
 add_executable(redux_tests
   regression_tests.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../src/account.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../src/file.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../src/input.cpp
 )
-
-target_include_directories(redux_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_features(redux_tests PRIVATE cxx_std_17)
-target_link_libraries(redux_tests PRIVATE cryptopp::cryptopp)
+target_link_libraries(redux_tests PRIVATE redux_core)
 
 add_test(NAME redux_regression_tests COMMAND redux_tests)
 
 # The end-of-input cases fail by hanging rather than returning if they ever regress, so cap the
 # run instead of letting CI block on it.
 set_tests_properties(redux_regression_tests PROPERTIES TIMEOUT 120)
+
+# p0_regressions.sh greps source and workflow files for specific fixes rather than exercising
+# built code, so it needs bash and standard POSIX tools -- not available on the Windows runners.
+if(NOT WIN32)
+  add_test(NAME redux_p0_regressions COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/p0_regressions.sh)
+endif()

--- a/tests/p0_regressions.sh
+++ b/tests/p0_regressions.sh
@@ -9,31 +9,47 @@ fail() {
   exit 1
 }
 
-rg -q 'first == std::string::npos' src/input.cpp \
+grep -qE 'first == std::string::npos' src/input.cpp \
   || fail "input trim should handle all-whitespace strings before slicing"
 
-rg -q 'getenv\("HOME"\)' src/file.cpp \
+grep -qE 'getenv\("HOME"\)' src/file.cpp \
   || fail "non-Windows user data path should be based on HOME"
 
-rg -q '"/home/"' src/file.cpp \
+grep -qE '"/home/"' src/file.cpp \
   && fail "non-Windows user data path still hard-codes /home"
 
-rg -q 'branches: \[ master \]' .github/workflows/codeql-analysis.yml \
+grep -qE 'branches: \[ master \]' .github/workflows/codeql-analysis.yml \
   && fail "CodeQL workflow still targets master instead of main"
 
-rg -q 'actions/checkout@v2|actions/upload-artifact@v2|github/codeql-action/(init|analyze)@v1' .github/workflows \
+grep -rqE 'actions/checkout@v2|actions/upload-artifact@v2|github/codeql-action/(init|analyze)@v1' .github/workflows \
   && fail "GitHub workflows still use deprecated v1/v2 actions"
 
-rg -q 'runs-on: (ubuntu-20\.04|macos-11|macos-13)' .github/workflows \
+grep -rqE 'runs-on: (ubuntu-20\.04|macos-11|macos-13)' .github/workflows \
   && fail "GitHub workflows still use old runner images"
 
-rg -q 'runs-on: macos-26$' .github/workflows/macOS-release.yml \
+grep -qE 'runs-on: macos-26$' .github/workflows/macOS-release.yml \
   || fail "macOS workflow should run on macos-26"
 
-rg -q 'cryptopp:arm64-osx' .github/workflows/macOS-release.yml \
-  || fail "macOS workflow should install Crypto++ for arm64-osx"
-
-rg -q 'cryptopp::cryptopp' src/CMakeLists.txt \
+grep -qE 'cryptopp::cryptopp' src/CMakeLists.txt \
   || fail "CMake should link the vcpkg-provided cryptopp::cryptopp target"
+
+# vcpkg dependencies are now pinned through the manifest (vcpkg.json) rather than an ad-hoc
+# `vcpkg install` step per workflow, so Crypto++ provisioning is verified there instead of by
+# grepping for a triplet in one platform's workflow.
+[ -f vcpkg.json ] \
+  || fail "vcpkg.json manifest is missing"
+
+grep -qE '"cryptopp"' vcpkg.json \
+  || fail "vcpkg.json should declare cryptopp as a dependency"
+
+grep -rqE 'vcpkg install cryptopp' .github/workflows \
+  && fail "workflows should rely on the vcpkg manifest instead of an ad-hoc vcpkg install step"
+
+# Every action reference must name a concrete release (vX.Y.Z), never a movable major tag like
+# @v4: a bare major tag silently changes what runs whenever upstream repoints it, while a
+# concrete version only changes when this repo deliberately edits it.
+if grep -rhE 'uses:.*@' .github/workflows | grep -vqE '@v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  fail "every workflow 'uses:' line must name a concrete release version (vX.Y.Z)"
+fi
 
 printf 'P0 regression checks passed.\n'

--- a/tests/regression_tests.cpp
+++ b/tests/regression_tests.cpp
@@ -668,6 +668,50 @@ namespace {
               "alice.csv's vault is intact and still ciphertext");
     }
 
+    // Two processes can both see a username as free before either creates it: the availability
+    // check runs before the lock, and the winner's lock is released when its session ends. The
+    // under-lock recheck in account::create is what must stop the loser from replacing the
+    // winner's vault with one keyed to its own password.
+    void create_refuses_to_replace_an_existing_account() {
+        section("create cannot clobber an existing account");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::vault::write("alice", {credential{"GitHub", "u", "gh-s3cret"}}, pw);
+
+        bool threw = false;
+        try {
+            account::create(user{"alice", "the-losers-password"});
+        } catch (account::already_exists const&) {
+            threw = true;
+        }
+        check(threw, "a second create for the same name throws already_exists");
+        check(account::valid_password(user{"alice", pw}), "the original password still works");
+        check(!account::valid_password(user{"alice", "the-losers-password"}),
+              "the racing password never took effect");
+        auto const creds = file::vault::read("alice", pw);
+        check(creds.size() == 1 && creds[0].password == "gh-s3cret",
+              "the original vault contents survived");
+    }
+
+    // The old format's account verifier lived at the exact path the vault now uses. There is
+    // deliberately no migration, so a leftover legacy file must read as "no account" -- login
+    // reports the account as absent instead of dying on bad magic, and signup can reclaim the
+    // name -- rather than squatting the username forever.
+    void a_legacy_file_does_not_squat_the_username() {
+        section("legacy files are reclaimable");
+
+        reset();
+        std::ofstream{file::vault::path("alice"), std::ios::binary}
+            << "legacy-format account verifier, no REDUXVLT magic";
+
+        check(!account::exists("alice"), "a file without the vault magic is not an account");
+
+        account::create(user{"alice", pw});
+        check(account::exists("alice"), "signup reclaimed the name");
+        check(account::valid_password(user{"alice", pw}), "the recreated account works");
+    }
+
     void config_dir_fails_closed_instead_of_falling_back_to_the_working_directory() {
         section("fail-closed config directory");
 
@@ -806,6 +850,8 @@ int main() {
              testcase{"account_lock", account_lock_is_exclusive_and_non_blocking},
              testcase{"CSV export", csv_export_quotes_fields_and_neutralizes_formulas},
              testcase{"CSV export namespace", csv_export_cannot_overwrite_another_accounts_vault},
+             testcase{"create cannot clobber", create_refuses_to_replace_an_existing_account},
+             testcase{"legacy files reclaimable", a_legacy_file_does_not_squat_the_username},
              testcase{"fail-closed config dir",
                       config_dir_fails_closed_instead_of_falling_back_to_the_working_directory},
              testcase{"end of input", exhausted_stdin_terminates_instead_of_spinning},

--- a/tests/regression_tests.cpp
+++ b/tests/regression_tests.cpp
@@ -1,12 +1,12 @@
 // Behavioural regression tests for Redux's storage layer.
 //
-// These link the real account.cpp / file.cpp and drive them against a throwaway HOME, so they
-// assert what the program actually does on disk rather than what the source looks like.
-// Every case here corresponds to a bug that was shipped at some point; they exist to stop it
-// coming back.
+// These link the real account.cpp / file.cpp and drive them against a throwaway config
+// directory, so they assert what the program actually does on disk rather than what the source
+// looks like. Every case here corresponds to a bug that was shipped at some point; they exist to
+// stop it coming back.
 //
-// POSIX only: the tests relocate the config directory by overriding HOME, which is how
-// file::user_files resolves it on POSIX but not on Windows.
+// The config directory is relocated via REDUX_CONFIG_DIR, which file::vault and friends check on
+// every platform (unlike overriding HOME, which does nothing on Windows).
 
 #include "account.h"
 #include "credential.h"
@@ -20,11 +20,14 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 namespace fs = std::filesystem;
 
@@ -32,6 +35,17 @@ namespace {
 
     int failures = 0;
     int checks = 0;
+
+    // setenv/unsetenv are POSIX; _putenv_s is the equivalent on Windows, where an empty value
+    // unsets the variable rather than setting it to an empty string.
+#ifdef _WIN32
+    void set_env(char const* name, std::string const& value) { _putenv_s(name, value.c_str()); }
+    // maybe_unused: its only caller, the fail-closed config-dir test, is POSIX-only.
+    [[maybe_unused]] void unset_env(char const* name) { _putenv_s(name, ""); }
+#else
+    void set_env(char const* name, std::string const& value) { setenv(name, value.c_str(), 1); }
+    void unset_env(char const* name) { unsetenv(name); }
+#endif
 
     void check(bool ok, std::string const& what) {
         ++checks;
@@ -45,12 +59,14 @@ namespace {
 
     fs::path sandbox;
 
-    fs::path config_dir() { return sandbox / ".config" / "Redux"; }
+    // REDUX_CONFIG_DIR names the config directory directly -- unlike HOME, there is no
+    // ".config/Redux" appended underneath it.
+    fs::path config_dir() { return sandbox; }
 
     void reset() {
         // Restore permissions first; a test may have made the directory read-only.
         std::error_code ec;
-        fs::permissions(config_dir(), fs::perms::owner_all, ec);
+        fs::permissions(sandbox, fs::perms::owner_all, ec);
         fs::remove_all(sandbox, ec);
         fs::create_directories(sandbox);
     }
@@ -58,6 +74,23 @@ namespace {
     std::string raw_bytes(fs::path const& p) {
         std::ifstream in{p, std::ios::binary};
         return std::string{std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+    }
+
+    void flip_byte_at(fs::path const& p, std::streamoff offset) {
+        std::fstream f{p, std::ios::binary | std::ios::in | std::ios::out};
+        f.seekg(offset);
+        char c = 0;
+        f.read(&c, 1);
+        c = static_cast<char>(c ^ 0xFF);
+        f.seekp(offset);
+        f.write(&c, 1);
+    }
+
+    void set_byte_at(fs::path const& p, std::streamoff offset, unsigned char value) {
+        std::fstream f{p, std::ios::binary | std::ios::in | std::ios::out};
+        f.seekp(offset);
+        char const c = static_cast<char>(value);
+        f.write(&c, 1);
     }
 
     void section(char const* name) { std::cout << "\n[" << name << "]\n"; }
@@ -70,26 +103,25 @@ namespace {
         section("username validation");
 
         for (auto const& bad : {
-                 "",                    // empty
-                 "/etc/passwd",         // absolute: operator/ would discard the base directory
-                 "../../../.bashrc",    // traversal
-                 "sub/alice",           // separator: parent directory would not exist
-                 "sub\\alice",          // Windows separator
-                 ".last_user",          // collides with Redux's own state file
-                 ".",                   // current directory
-                 "..",                  // parent directory
-                 "alice$(whoami)",      // shell metacharacters
-                 "alice name",          // space
+                 "",                 // empty
+                 "/etc/passwd",      // absolute: operator/ would discard the base directory
+                 "../../../.bashrc", // traversal
+                 "sub/alice",        // separator: parent directory would not exist
+                 "sub\\alice",       // Windows separator
+                 ".last_user",       // collides with Redux's own state file
+                 ".",                // current directory
+                 "..",               // parent directory
+                 "alice$(whoami)",   // shell metacharacters
+                 "alice name",       // space
              }) {
-            check(!account::valid_username(bad),
-                  std::string{"rejects \""} + bad + '"');
+            check(!account::valid_username(bad), std::string{"rejects \""} + bad + '"');
         }
 
         check(!account::valid_username(std::string(65, 'a')), "rejects a 65-character name");
         check(account::valid_username(std::string(64, 'a')), "accepts a 64-character name");
 
-        for (auto const& good : {"alice", "Alice99", "alice_smith", "alice-smith", "alice.smith",
-                                 "a"}) {
+        for (auto const& good :
+             {"alice", "Alice99", "alice_smith", "alice-smith", "alice.smith", "a"}) {
             check(account::valid_username(good), std::string{"accepts \""} + good + '"');
         }
     }
@@ -97,6 +129,10 @@ namespace {
     void a_failing_write_leaves_the_previous_vault_intact() {
         section("writes are atomic and report failure");
 
+#ifdef _WIN32
+        std::cout << "  skip  a read-only directory attribute does not block file creation on "
+                     "Windows\n";
+#else
         if (geteuid() == 0) {
             std::cout << "  skip  running as root, directory permissions would not be enforced\n";
             return;
@@ -104,12 +140,10 @@ namespace {
 
         reset();
         account::create(user{"alice", pw});
+        file::vault::write("alice", {credential{"GitHub", "u@example.com", "gh-s3cret"}}, pw);
 
-        std::vector<credential> const creds{credential{"GitHub", "u@example.com", "gh-s3cret"}};
-        std::string const data = file::user_files::data("alice");
-        file::credentials::write(data, creds, pw);
-
-        std::string const before = raw_bytes(data);
+        auto const vault_path = file::vault::path("alice");
+        std::string const before = raw_bytes(vault_path);
         check(!before.empty(), "vault written");
 
         // Make the directory unwritable so the staging file cannot be created.
@@ -117,7 +151,7 @@ namespace {
 
         bool threw = false;
         try {
-            file::credentials::write(data, {credential{"Replacement", "x", "y"}}, pw);
+            file::vault::write("alice", {credential{"Replacement", "x", "y"}}, pw);
         } catch (std::exception const&) {
             threw = true;
         }
@@ -125,13 +159,14 @@ namespace {
         fs::permissions(config_dir(), fs::perms::owner_all);
 
         check(threw, "a write that cannot succeed throws instead of failing silently");
-        check(raw_bytes(data) == before, "the previous vault is byte-for-byte intact");
-        check(fs::exists(data) && fs::file_size(data) > 0,
+        check(raw_bytes(vault_path) == before, "the previous vault is byte-for-byte intact");
+        check(fs::exists(vault_path) && fs::file_size(vault_path) > 0,
               "the vault was never truncated to 0 bytes");
 
-        auto recovered = file::credentials::read(data, pw);
+        auto recovered = file::vault::read("alice", pw);
         check(recovered.size() == 1 && recovered[0].password == "gh-s3cret",
               "the original credential is still readable");
+#endif
     }
 
     void no_staging_file_is_left_behind() {
@@ -139,16 +174,15 @@ namespace {
 
         reset();
         account::create(user{"alice", pw});
-        file::credentials::write(file::user_files::data("alice"),
-                                 {credential{"GitHub", "u", "s"}}, pw);
+        file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
 
         bool leftover = false;
         for (auto const& e : fs::directory_iterator{config_dir()}) {
-            if (e.path().extension() == ".new") {
+            if (e.path().extension() == ".tmp") {
                 leftover = true;
             }
         }
-        check(!leftover, "no '.new' staging file remains after a successful write");
+        check(!leftover, "no '.tmp' staging file remains after a successful write");
     }
 
     void vault_files_are_not_readable_by_others() {
@@ -157,11 +191,13 @@ namespace {
         reset();
         account::create(user{"alice", pw});
 
-        for (auto const& p : {file::user_files::account("alice"), file::user_files::data("alice")}) {
-            auto perms = fs::status(p).permissions();
-            check((perms & (fs::perms::group_all | fs::perms::others_all)) == fs::perms::none,
-                  fs::path{p}.filename().string() + " is owner-only");
-        }
+#ifndef _WIN32
+        auto perms = fs::status(file::vault::path("alice")).permissions();
+        check((perms & (fs::perms::group_all | fs::perms::others_all)) == fs::perms::none,
+              "vault file is owner-only");
+#else
+        std::cout << "  skip  POSIX mode bits do not apply on Windows\n";
+#endif
     }
 
     void secrets_never_appear_in_cleartext_on_disk() {
@@ -169,17 +205,14 @@ namespace {
 
         reset();
         account::create(user{"alice", pw});
-        std::string const data = file::user_files::data("alice");
-        file::credentials::write(
-            data, {credential{"GitHub", "alice@example.com", "gh-s3cret-token"}}, pw);
+        file::vault::write("alice", {credential{"GitHub", "alice@example.com", "gh-s3cret-token"}},
+                           pw);
 
-        auto const bytes = raw_bytes(data);
+        auto const bytes = raw_bytes(file::vault::path("alice"));
         for (auto const& secret : {"gh-s3cret-token", "alice@example.com", "GitHub", pw.c_str()}) {
             check(bytes.find(secret) == std::string::npos,
                   std::string{"vault does not contain \""} + secret + "\" in cleartext");
         }
-        check(raw_bytes(file::user_files::account("alice")).find(pw) == std::string::npos,
-              "account file does not contain the master password");
     }
 
     void a_wrong_password_does_not_lock_the_account_out() {
@@ -201,8 +234,7 @@ namespace {
 
         reset();
         account::create(user{"alice", pw});
-        std::string const data = file::user_files::data("alice");
-        file::credentials::write(data, {credential{"GitHub", "u", "gh-s3cret"}}, pw);
+        file::vault::write("alice", {credential{"GitHub", "u", "gh-s3cret"}}, pw);
 
         std::string const newpw = "a-brand-new-passphrase";
         account::change_password(user{"alice", pw}, newpw);
@@ -210,35 +242,17 @@ namespace {
         check(!account::valid_password(user{"alice", pw}), "old password no longer works");
         check(account::valid_password(user{"alice", newpw}), "new password works");
 
-        auto after = file::credentials::read(data, newpw);
+        auto after = file::vault::read("alice", newpw);
         check(after.size() == 1 && after[0].password == "gh-s3cret",
               "vault readable under the new password, contents intact");
 
         bool old_fails = false;
         try {
-            (void)file::credentials::read(data, pw);
+            (void)file::vault::read("alice", pw);
         } catch (std::exception const&) {
             old_fails = true;
         }
         check(old_fails, "vault not readable under the old password");
-    }
-
-    void changing_the_password_with_no_vault_does_not_throw() {
-        section("change_password with an absent vault");
-
-        reset();
-        account::create(user{"alice", pw});
-        fs::remove(file::user_files::data("alice"));
-
-        bool threw = false;
-        try {
-            account::change_password(user{"alice", pw}, "a-brand-new-passphrase");
-        } catch (std::exception const&) {
-            threw = true;
-        }
-        check(!threw, "an absent vault is handled rather than aborting the program");
-        check(account::valid_password(user{"alice", "a-brand-new-passphrase"}),
-              "the password change still took effect");
     }
 
     void the_remembered_username_holds_no_secret() {
@@ -252,70 +266,382 @@ namespace {
         check(raw_bytes(p) == "alice", "file contains exactly the username");
         check(raw_bytes(p).find(pw) == std::string::npos, "file contains no password");
 
+#ifndef _WIN32
         auto perms = fs::status(p).permissions();
         check((perms & (fs::perms::group_all | fs::perms::others_all)) == fs::perms::none,
               ".last_user is owner-only");
+#endif
     }
 
-    // Two accounts must never map onto each other's files. Both of these were real collisions:
-    // "alice_data" took over "alice"'s vault under the old suffix, and "alice.new" collided with
-    // the staging file used while saving "alice".
+    // Two accounts must never map onto each other's files. These neighbour names probe every
+    // string Redux still derives from a username: the lock file name (".<name>.lock") and the
+    // staging name used while writing (dot-prefixed, pid + random suffix). Each of these is a
+    // name a user can register.
     void one_account_cannot_overwrite_another() {
         section("account file paths cannot collide");
 
         reset();
 
-        // Names chosen to probe every string Redux derives from "alice": the vault suffix and the
-        // staging name used while writing a file. Each of these is a name a user can register.
-        std::vector<std::string> const neighbours{"alice_data", "alice.new", "alice.vault",
-                                                  "alice_datavault"};
+        std::vector<std::string> const neighbours{"alice.lock", "alice.tmp", "alice_data"};
         std::string const npw = "neighbour-password";
 
         account::create(user{"alice", pw});
-        file::credentials::write(file::user_files::data("alice"),
-                                 {credential{"GitHub", "u", "alice-secret"}}, pw);
+        file::vault::write("alice", {credential{"GitHub", "u", "alice-secret"}}, pw);
 
         for (auto const& n : neighbours) {
             check(account::valid_username(n), n + " is a name a user could register");
             account::create(user{n, npw});
-            file::credentials::write(file::user_files::data(n),
-                                     {credential{"Site", "u", n + "-secret"}}, npw);
+            file::vault::write(n, {credential{"Site", "u", n + "-secret"}}, npw);
         }
 
-        // Every derived path must be distinct.
-        std::vector<std::string> paths{file::user_files::account("alice"),
-                                       file::user_files::data("alice")};
+        // Every derived vault path must be distinct.
+        std::vector<std::string> paths{file::vault::path("alice").string()};
         for (auto const& n : neighbours) {
-            paths.push_back(file::user_files::account(n));
-            paths.push_back(file::user_files::data(n));
+            paths.push_back(file::vault::path(n).string());
         }
         std::sort(paths.begin(), paths.end());
         check(std::adjacent_find(paths.begin(), paths.end()) == paths.end(),
-              "no two account or vault paths are identical");
+              "no two account vault paths are identical");
 
-        // Rewrite alice's files now that the neighbours exist. This is the moment a colliding
-        // suffix or staging name does its damage: staging is created and then renamed away, so it
-        // would take a neighbour's file with it.
+        // Rewrite alice's files now that the neighbours exist -- this is the moment a colliding
+        // lock or staging name would do its damage: both are created and then released or
+        // renamed away while a neighbour's account is on disk.
         account::change_password(user{"alice", pw}, pw);
-        file::credentials::write(file::user_files::data("alice"),
-                                 {credential{"GitHub", "u", "alice-secret"}}, pw);
+        file::vault::write("alice", {credential{"GitHub", "u", "alice-secret"}}, pw);
 
         check(account::valid_password(user{"alice", pw}), "alice's account still works");
-        auto alice_creds = file::credentials::read(file::user_files::data("alice"), pw);
+        auto alice_creds = file::vault::read("alice", pw);
         check(alice_creds.size() == 1 && alice_creds[0].password == "alice-secret",
               "alice's vault is intact");
 
         for (auto const& n : neighbours) {
-            check(account::valid_password(user{n, npw}),
-                  n + "'s account survived writes to alice");
+            check(account::valid_password(user{n, npw}), n + "'s account survived writes to alice");
             std::vector<credential> c;
             try {
-                c = file::credentials::read(file::user_files::data(n), npw);
+                c = file::vault::read(n, npw);
             } catch (std::exception const&) {
                 // leave c empty; the check below reports it
             }
             check(c.size() == 1 && c[0].password == n + "-secret", n + "'s vault is intact");
         }
+    }
+
+    void the_envelope_starts_with_the_expected_magic_and_version() {
+        section("envelope header");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+        auto const first = raw_bytes(file::vault::path("alice"));
+
+        check(first.size() >= 43, "vault is at least as large as the 43-byte header");
+        check(first.compare(0, 8, "REDUXVLT", 8) == 0, "vault begins with the REDUXVLT magic");
+        check(static_cast<unsigned char>(first[8]) == 1, "vault declares format version 1");
+
+        file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+        auto const second = raw_bytes(file::vault::path("alice"));
+
+        check(first.compare(14, 16, second, 14, 16) != 0,
+              "salt differs between two writes of the same data");
+        check(first.compare(31, 12, second, 31, 12) != 0,
+              "nonce differs between two writes of the same data");
+    }
+
+    void the_header_declares_scrypt_parameters_at_least_as_strong_as_the_minimum() {
+        section("scrypt parameters");
+
+        reset();
+        account::create(user{"alice", pw});
+        auto const bytes = raw_bytes(file::vault::path("alice"));
+
+        check(static_cast<unsigned char>(bytes[9]) == 1, "kdf id is scrypt (1)");
+        check(static_cast<unsigned char>(bytes[10]) >= 15, "log2(N) is at least 15");
+        check(static_cast<unsigned char>(bytes[11]) >= 8, "r is at least 8");
+        check(static_cast<unsigned char>(bytes[12]) >= 1, "p is at least 1");
+    }
+
+    void wrong_password_is_false_but_a_corrupted_header_throws() {
+        section("error taxonomy: wrong password vs. corruption");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+
+        check(!account::valid_password(user{"alice", "wrong-password"}),
+              "a wrong password returns false");
+
+        // Flip a magic byte: corrupts the header, not the ciphertext, so the failure has nothing
+        // to do with the password at all.
+        flip_byte_at(file::vault::path("alice"), 0);
+
+        bool threw = false;
+        try {
+            (void)account::valid_password(user{"alice", pw});
+        } catch (std::exception const&) {
+            threw = true;
+        }
+        check(threw, "a corrupted header throws rather than merely returning false");
+    }
+
+    void truncated_ciphertext_throws() {
+        section("truncated body");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+
+        auto const p = file::vault::path("alice");
+        auto const full = raw_bytes(p);
+        check(full.size() > 43, "vault has a non-empty ciphertext body");
+
+        {
+            std::ofstream out{p, std::ios::binary | std::ios::trunc};
+            out.write(full.data(), static_cast<std::streamsize>(full.size() - 5));
+        }
+
+        bool threw = false;
+        try {
+            (void)file::vault::read("alice", pw);
+        } catch (std::exception const&) {
+            threw = true;
+        }
+        check(threw, "a truncated vault throws on read");
+    }
+
+    void tampering_with_the_header_salt_is_detected() {
+        section("header is authenticated (AAD)");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+
+        // Byte 14 is the first salt byte; the ciphertext body is untouched.
+        flip_byte_at(file::vault::path("alice"), 14);
+
+        bool threw = false;
+        try {
+            (void)file::vault::read("alice", pw);
+        } catch (std::exception const&) {
+            threw = true;
+        }
+        check(threw, "tampering with a salt byte (body untouched) is caught by the AAD tag");
+    }
+
+    // The scrypt r and p bytes (header offsets 11 and 12) reach key derivation before the GCM
+    // tag check authenticates the header, so an out-of-range value must be rejected as an
+    // unsupported format -- fast, without deriving a key -- rather than forcing a huge
+    // allocation and only then failing the tag check.
+    void hostile_scrypt_parameters_are_rejected_before_key_derivation() {
+        section("hostile scrypt parameters in the header");
+
+        auto rejected_as_unsupported = [](std::streamoff offset, unsigned char value) {
+            reset();
+            account::create(user{"alice", pw});
+            file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+            set_byte_at(file::vault::path("alice"), offset, value);
+
+            try {
+                (void)file::vault::read("alice", pw);
+            } catch (std::runtime_error const& e) {
+                // The unsupported-format error, not HashVerificationFailed: the latter would
+                // mean key derivation ran and only the tag check caught the tampering.
+                return std::string{e.what()}.find("unsupported Redux vault format") !=
+                       std::string::npos;
+            } catch (std::exception const&) {
+            }
+            return false;
+        };
+
+        check(rejected_as_unsupported(11, 200), "r = 200 is rejected without deriving a key");
+        check(rejected_as_unsupported(11, 0), "r = 0 is rejected");
+        check(rejected_as_unsupported(12, 200), "p = 200 is rejected without deriving a key");
+        check(rejected_as_unsupported(12, 0), "p = 0 is rejected");
+    }
+
+    void a_vault_copied_onto_another_username_is_rejected() {
+        section("username recorded in the plaintext must match the account");
+
+        reset();
+        account::create(user{"alice", pw});
+        file::vault::write("alice", {credential{"GitHub", "u", "alice-secret"}}, pw);
+        account::create(user{"bob", pw});
+
+        fs::copy_file(file::vault::path("alice"), file::vault::path("bob"),
+                      fs::copy_options::overwrite_existing);
+
+        bool read_threw = false;
+        try {
+            (void)file::vault::read("bob", pw);
+        } catch (std::exception const&) {
+            read_threw = true;
+        }
+        check(read_threw,
+              "reading alice's vault under bob's name throws rather than returning data");
+
+        bool valid_password_threw = false;
+        try {
+            (void)account::valid_password(user{"bob", pw});
+        } catch (std::exception const&) {
+            valid_password_threw = true;
+        }
+        check(valid_password_threw,
+              "valid_password propagates the mismatch instead of reporting it as a wrong password");
+    }
+
+    void account_lock_is_exclusive_and_non_blocking() {
+        section("account_lock");
+
+        reset();
+        account::create(user{"alice", pw});
+
+        std::optional<file::account_lock> first;
+        first.emplace("alice");
+
+        bool busy = false;
+        try {
+            file::account_lock second{"alice"};
+            (void)second;
+        } catch (file::account_busy const&) {
+            busy = true;
+        }
+        check(busy, "a second lock on the same account is refused while the first is held");
+
+        first.reset();
+
+        bool threw_after_release = false;
+        try {
+            file::account_lock third{"alice"};
+            (void)third;
+        } catch (std::exception const&) {
+            threw_after_release = true;
+        }
+        check(!threw_after_release, "the lock can be acquired again once the first is released");
+    }
+
+    // A minimal RFC-4180 field parser -- enough to check column counts and quoting for this
+    // test, not a general CSV library.
+    std::vector<std::string> parse_csv_line(std::string const& line) {
+        std::vector<std::string> fields;
+        std::string field;
+        bool in_quotes = false;
+        for (std::size_t i = 0; i < line.size(); ++i) {
+            char const c = line[i];
+            if (in_quotes) {
+                if (c == '"') {
+                    if (i + 1 < line.size() && line[i + 1] == '"') {
+                        field += '"';
+                        ++i;
+                    } else {
+                        in_quotes = false;
+                    }
+                } else {
+                    field += c;
+                }
+            } else if (c == '"') {
+                in_quotes = true;
+            } else if (c == ',') {
+                fields.push_back(field);
+                field.clear();
+            } else {
+                field += c;
+            }
+        }
+        fields.push_back(field);
+        return fields;
+    }
+
+    void csv_export_quotes_fields_and_neutralizes_formulas() {
+        section("CSV export");
+
+        reset();
+        std::vector<credential> const creds{
+            credential{"Ac,me", "user,name", "pa\"ss"},
+            credential{"=2+3", "@cmd", "value"},
+        };
+
+        auto const csv_path = sandbox / "alice.csv";
+        file::users::writeToCSV(csv_path.string(), creds);
+
+        check(fs::exists(csv_path), "CSV file was written");
+
+#ifndef _WIN32
+        auto perms = fs::status(csv_path).permissions();
+        check((perms & (fs::perms::group_all | fs::perms::others_all)) == fs::perms::none,
+              "CSV file is owner-only");
+#endif
+
+        std::string const contents = raw_bytes(csv_path);
+
+        std::istringstream lines{contents};
+        std::string line;
+        std::vector<std::vector<std::string>> rows;
+        while (std::getline(lines, line)) {
+            if (!line.empty()) {
+                rows.push_back(parse_csv_line(line));
+            }
+        }
+
+        check(rows.size() == 3, "header plus two credential rows");
+        for (auto const& row : rows) {
+            check(row.size() == 4, "exactly 4 columns per row");
+        }
+
+        check(rows[1][1] == "Ac,me", "embedded comma in company name survives round-trip");
+        check(rows[1][2] == "user,name", "embedded comma in username survives round-trip");
+        check(rows[1][3] == "pa\"ss", "embedded quote survives round-trip");
+
+        check(rows[2][1] == "'=2+3", "a leading '=' is neutralized with a leading single quote");
+        check(rows[2][2] == "'@cmd", "a leading '@' is neutralized with a leading single quote");
+
+        check(contents.find("\"=2+3\"") == std::string::npos,
+              "the raw file never contains an unneutralized formula-looking field");
+    }
+
+    void config_dir_fails_closed_instead_of_falling_back_to_the_working_directory() {
+        section("fail-closed config directory");
+
+#ifdef _WIN32
+        // On Windows the profile directory is resolved from the process token, not the
+        // environment, so there is no environment-only failure to simulate -- unsetting the
+        // variables would just make the probe land in the real %USERPROFILE%\Redux.
+        std::cout << "  skip  the profile directory comes from the process token, not the "
+                     "environment\n";
+#else
+        char const* saved_redux_dir = std::getenv("REDUX_CONFIG_DIR");
+        std::string const saved_redux_dir_value = saved_redux_dir ? saved_redux_dir : "";
+        char const* saved_home = std::getenv("HOME");
+        std::string const saved_home_value = saved_home ? saved_home : "";
+        bool const had_home = saved_home != nullptr;
+
+        unset_env("REDUX_CONFIG_DIR");
+        unset_env("HOME");
+
+        auto const cwd = fs::current_path();
+        std::vector<std::string> before_entries;
+        for (auto const& e : fs::directory_iterator{cwd}) {
+            before_entries.push_back(e.path().filename().string());
+        }
+
+        bool threw = false;
+        try {
+            account::create(user{"cwd-probe", pw});
+        } catch (std::exception const&) {
+            threw = true;
+        }
+        check(threw, "vault operations throw rather than silently using the working directory");
+
+        std::vector<std::string> after_entries;
+        for (auto const& e : fs::directory_iterator{cwd}) {
+            after_entries.push_back(e.path().filename().string());
+        }
+        check(before_entries.size() == after_entries.size(),
+              "no file was created in the current working directory");
+
+        set_env("REDUX_CONFIG_DIR", saved_redux_dir_value);
+        if (had_home) {
+            set_env("HOME", saved_home_value);
+        }
+#endif
     }
 
     // An exhausted stdin used to make input::choice spin forever: clear() followed by ignore()
@@ -377,7 +703,7 @@ namespace {
 int main() {
     sandbox = fs::temp_directory_path() / "redux-regression-tests";
     reset();
-    setenv("HOME", sandbox.c_str(), 1);
+    set_env("REDUX_CONFIG_DIR", sandbox.string());
 
     // Each case is run under its own handler so an unexpected exception is reported as a failure
     // rather than aborting the process and hiding which case broke.
@@ -395,9 +721,21 @@ int main() {
              testcase{"ciphertext at rest", secrets_never_appear_in_cleartext_on_disk},
              testcase{"no lockout", a_wrong_password_does_not_lock_the_account_out},
              testcase{"change_password", changing_the_password_re_encrypts_the_vault},
-             testcase{"change_password, no vault", changing_the_password_with_no_vault_does_not_throw},
              testcase{"remembered username", the_remembered_username_holds_no_secret},
              testcase{"path collisions", one_account_cannot_overwrite_another},
+             testcase{"envelope header", the_envelope_starts_with_the_expected_magic_and_version},
+             testcase{"scrypt parameters",
+                      the_header_declares_scrypt_parameters_at_least_as_strong_as_the_minimum},
+             testcase{"error taxonomy", wrong_password_is_false_but_a_corrupted_header_throws},
+             testcase{"truncated body", truncated_ciphertext_throws},
+             testcase{"AAD tampering", tampering_with_the_header_salt_is_detected},
+             testcase{"hostile scrypt parameters",
+                      hostile_scrypt_parameters_are_rejected_before_key_derivation},
+             testcase{"username mismatch", a_vault_copied_onto_another_username_is_rejected},
+             testcase{"account_lock", account_lock_is_exclusive_and_non_blocking},
+             testcase{"CSV export", csv_export_quotes_fields_and_neutralizes_formulas},
+             testcase{"fail-closed config dir",
+                      config_dir_fails_closed_instead_of_falling_back_to_the_working_directory},
              testcase{"end of input", exhausted_stdin_terminates_instead_of_spinning},
              testcase{"no session state", nothing_on_disk_grants_a_session},
          }) {
@@ -411,7 +749,7 @@ int main() {
     }
 
     std::error_code ec;
-    fs::permissions(config_dir(), fs::perms::owner_all, ec);
+    fs::permissions(sandbox, fs::perms::owner_all, ec);
     fs::remove_all(sandbox, ec);
 
     std::cout << "\n" << (checks - failures) << "/" << checks << " checks passed\n";

--- a/tests/regression_tests.cpp
+++ b/tests/regression_tests.cpp
@@ -477,6 +477,29 @@ namespace {
             }
             check(rejected, "log2(N) = 24 with r = 32 (64 GiB combined) is rejected");
         }
+
+        // log2(N) = 21, r = 1, p = 16 fits under the 256 MiB memory ceiling, but its N * r * p
+        // work factor is 128 times the write-side default -- a corrupted header must not be
+        // able to stall login for tens of seconds either.
+        {
+            reset();
+            account::create(user{"alice", pw});
+            file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+            set_byte_at(file::vault::path("alice"), 10, 21);
+            set_byte_at(file::vault::path("alice"), 11, 1);
+            set_byte_at(file::vault::path("alice"), 12, 16);
+
+            bool rejected = false;
+            try {
+                (void)file::vault::read("alice", pw);
+            } catch (std::runtime_error const& e) {
+                rejected = std::string{e.what()}.find("unsupported Redux vault format") !=
+                           std::string::npos;
+            } catch (std::exception const&) {
+            }
+            check(rejected, "log2(N) = 21 with r = 1, p = 16 (memory-safe but 128x work) is "
+                            "rejected");
+        }
     }
 
     void a_vault_copied_onto_another_username_is_rejected() {
@@ -618,6 +641,33 @@ namespace {
               "the raw file never contains an unneutralized formula-looking field");
     }
 
+    // "alice.csv" is a name a user can register, and vault files carry no suffix -- so a naive
+    // "<username>.csv" export name would BE that account's vault path, and exporting from
+    // "alice" would replace a whole vault with plaintext CSV. The '@' in the export name is
+    // what makes the collision impossible: it can never appear in a valid username.
+    void csv_export_cannot_overwrite_another_accounts_vault() {
+        section("CSV export stays outside the vault namespace");
+
+        reset();
+
+        check(account::valid_username("alice.csv"), "alice.csv is a name a user could register");
+        account::create(user{"alice.csv", pw});
+        file::vault::write("alice.csv", {credential{"Site", "u", "csv-account-secret"}}, pw);
+
+        check(file::user_files::export_path("alice") !=
+                  file::vault::path("alice.csv").string(),
+              "alice's export path is not alice.csv's vault path");
+
+        file::users::writeToCSV(file::user_files::export_path("alice"),
+                                {credential{"GitHub", "u", "alice-secret"}});
+
+        check(account::valid_password(user{"alice.csv", pw}),
+              "alice.csv's account survived alice's CSV export");
+        auto const survived = file::vault::read("alice.csv", pw);
+        check(survived.size() == 1 && survived[0].password == "csv-account-secret",
+              "alice.csv's vault is intact and still ciphertext");
+    }
+
     void config_dir_fails_closed_instead_of_falling_back_to_the_working_directory() {
         section("fail-closed config directory");
 
@@ -755,6 +805,7 @@ int main() {
              testcase{"username mismatch", a_vault_copied_onto_another_username_is_rejected},
              testcase{"account_lock", account_lock_is_exclusive_and_non_blocking},
              testcase{"CSV export", csv_export_quotes_fields_and_neutralizes_formulas},
+             testcase{"CSV export namespace", csv_export_cannot_overwrite_another_accounts_vault},
              testcase{"fail-closed config dir",
                       config_dir_fails_closed_instead_of_falling_back_to_the_working_directory},
              testcase{"end of input", exhausted_stdin_terminates_instead_of_spinning},

--- a/tests/regression_tests.cpp
+++ b/tests/regression_tests.cpp
@@ -456,6 +456,27 @@ namespace {
         check(rejected_as_unsupported(11, 0), "r = 0 is rejected");
         check(rejected_as_unsupported(12, 200), "p = 200 is rejected without deriving a key");
         check(rejected_as_unsupported(12, 0), "p = 0 is rejected");
+
+        // Individually, log2(N) = 24 and r = 32 each pass their own range check; combined, the
+        // scrypt working set is 128 * 2^24 * 32 = 64 GiB. The product ceiling has to reject the
+        // pair before key derivation -- per-parameter bounds alone cannot.
+        {
+            reset();
+            account::create(user{"alice", pw});
+            file::vault::write("alice", {credential{"GitHub", "u", "s"}}, pw);
+            set_byte_at(file::vault::path("alice"), 10, 24);
+            set_byte_at(file::vault::path("alice"), 11, 32);
+
+            bool rejected = false;
+            try {
+                (void)file::vault::read("alice", pw);
+            } catch (std::runtime_error const& e) {
+                rejected = std::string{e.what()}.find("unsupported Redux vault format") !=
+                           std::string::npos;
+            } catch (std::exception const&) {
+            }
+            check(rejected, "log2(N) = 24 with r = 32 (64 GiB combined) is rejected");
+        }
     }
 
     void a_vault_copied_onto_another_username_is_rejected() {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "redux",
+  "version-string": "1.11",
+  "dependencies": [
+    "cryptopp"
+  ],
+  "builtin-baseline": "25b93347d8b1cb83bba83899c85455de050b8d02"
+}


### PR DESCRIPTION
## Summary

Full remediation of the security audit (all findings verified against source before fixing).

### High severity
- **Master-password KDF**: replaced Crypto++ `DefaultEncryptorWithMAC` (8-byte salt, 2,500 Mash iterations) with **scrypt (N=2^15, r=8, p=1) → AES-256-GCM**. The vault is one versioned envelope per account (`REDUXVLT` magic; version, KDF id, parameters, salt, nonce in a 43-byte header authenticated as GCM AAD).
- **Password-change stranding**: the separate account-verifier file is gone; a password change is now a single atomic staging+rename of one file.
- **Fail-open storage location**: `config_dir()` now throws instead of falling back to the working directory; every Windows profile API result is checked. `REDUX_CONFIG_DIR` added as an explicit override (doubles as the portable test hook).

### Medium
- Unique staging names (`.name.pid.hex.tmp`) + per-account session locks (`flock`/`LockFileEx`), so concurrent instances can't race; second instance gets a clean "account in use" message.
- Windows owner-only protection is now a real protected DACL for the current user's SID, not the read-only attribute.
- CSV export: RFC-4180 quoting, doubled quotes, OWASP formula-injection neutralization (`= + - @ TAB CR`), atomic owner-only write, plaintext warning.
- Windows password echo: original console mode captured and restored; fails closed if echo can't be disabled on a real console.
- Error taxonomy: `valid_password` is false only on MAC verification failure; I/O and format errors propagate honestly.

### Lower priority
- Signup now confirms the master password (shared flow with change-password).
- `system("cls")` removed (ANSI escapes + VT enable on Windows); README's antivirus note retired.
- `file(GLOB)` replaced by explicit lists via a shared `redux_core` library; signed/unsigned warnings fixed (`-Wall -Wextra` / `/W4` clean).
- README corrected (CMake ≥ 3.22, manifest-based builds, testing docs, vault-format note).

### Tests & CI
- Regression suite reworked/extended: **96/96 passing, plain and under ASan/UBSan**; suite now runs on Linux, macOS, and Windows CI; `p0_regressions.sh` ported to grep and registered with CTest.
- New security tests: format header, hostile scrypt parameters (pre-auth allocation bound), tamper/AAD, error taxonomy, lock exclusivity, CSV injection, fail-closed directory.
- Workflows pinned to concrete action releases (`checkout@v7.0.1`, `upload-artifact@v7.0.1`, `codeql-action@v4.37.4` — includes the CodeQL v3→v4 migration); Crypto++ pinned via `vcpkg.json` manifest baseline; a p0 check enforces concrete `vX.Y.Z` action refs.

### Breaking change (intentional)
Vaults created before this change are **not readable** — no migration, per owner decision (personal use). Recreate the account on first run.

### Review process
Implemented via staged multi-agent run: independent adversarial review of the full diff found 7 issues (2 high — a Windows lock share-mode bug and a Windows-CI test landmine; 1 medium — unvalidated header `r`/`p` enabling a ~875 MB pre-authentication allocation from one corrupted byte); all confirmed findings fixed and re-gated.

### Watch on first CI run
Manifest-mode vcpkg provisioning and the Windows/macOS test steps are exercised for the first time by this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)